### PR TITLE
Recursive mode customisations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,14 @@
     <NoWarn>NU1507;$(NoWarn)</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="JsonPointer.Net" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageVersion Include="JsonPointer.Net" Version="3.2.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.2" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 0,
-  "Minor": 10,
+  "Minor": 11,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
+++ b/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="JsonPointer.Net" />
   </ItemGroup>
@@ -25,6 +26,13 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/JsonTimeSeriesExtractor/ParsedTimestamp.cs
+++ b/src/JsonTimeSeriesExtractor/ParsedTimestamp.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+using Json.Pointer;
+
+namespace Jaahas.Json {
+
+    /// <summary>
+    /// A timestamp for a <see cref="TimeSeriesSample"/>.
+    /// </summary>
+    internal readonly struct ParsedTimestamp {
+
+        /// <summary>
+        /// The timestamp.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// The source of the timestamp.
+        /// </summary>
+        public TimestampSource Source { get; }
+
+        /// <summary>
+        /// The JSON pointer to the element that the timestamp was parsed from, if <see cref="Source"/> 
+        /// is <see cref="TimestampSource.Document"/>.
+        /// </summary>
+        public JsonPointer? Pointer { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="ParsedTimestamp"/> instance.
+        /// </summary>
+        /// <param name="timestamp">
+        ///   The timestamp.
+        /// </param>
+        /// <param name="source">
+        ///   The source of the timestamp.
+        /// </param>
+        /// <param name="pointer">
+        ///   The JSON pointer to the element that the timestamp was parsed from, if <paramref name="source"/> 
+        ///   is <see cref="TimestampSource.Document"/>.
+        /// </param>
+        public ParsedTimestamp(DateTimeOffset timestamp, TimestampSource source, JsonPointer? pointer) {
+            Timestamp = timestamp;
+            Source = source;
+            Pointer = pointer;
+        }
+
+    }
+}

--- a/src/JsonTimeSeriesExtractor/Resources.Designer.cs
+++ b/src/JsonTimeSeriesExtractor/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace Jaahas.Json {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid JSON poiinter..
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid JSON pointer..
         /// </summary>
         internal static string Error_InvalidJsonPointer {
             get {

--- a/src/JsonTimeSeriesExtractor/Resources.resx
+++ b/src/JsonTimeSeriesExtractor/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Error_InvalidJsonPointer" xml:space="preserve">
-    <value>'{0}' is not a valid JSON poiinter.</value>
+    <value>'{0}' is not a valid JSON pointer.</value>
     <comment>{0} - invalid pointer</comment>
   </data>
   <data name="Error_UnresolvedTemplateParameter" xml:space="preserve">

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorContext.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorContext.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+
+using Json.Pointer;
+
+namespace Jaahas.Json {
+
+    /// <summary>
+    /// The context to use when extracting samples using <see cref="TimeSeriesExtractor"/>.
+    /// </summary>
+    internal sealed class TimeSeriesExtractorContext {
+
+        /// <summary>
+        /// The extractor options.
+        /// </summary>
+        internal TimeSeriesExtractorOptions Options { get; }
+
+        /// <summary>
+        /// The <see cref="JsonPointer"/> that corresponds to the timestamp property.
+        /// </summary>
+        internal JsonPointer? TimestampPointer { get; }
+
+        /// <summary>
+        /// A delegate that determines whether a document property should be extracted as a time series.
+        /// </summary>
+        internal Func<JsonPointer, bool> IncludeElement { get; }
+
+        /// <summary>
+        /// The stack of JSON elements that are currently being processed.
+        /// </summary>
+        internal Stack<KeyValuePair<string?, JsonElement>> ElementStack { get; }
+
+        /// <summary>
+        /// The stack of timestamps that are currently being processed.
+        /// </summary>
+        internal Stack<ParsedTimestamp> TimestampStack { get; }
+
+        /// <summary>
+        /// Specifies whether the default sample key template is being used.
+        /// </summary>
+        internal bool IsDefaultSampleKeyTemplate { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="TimeSeriesExtractorContext"/> instance.
+        /// </summary>
+        /// <param name="options">
+        ///   The extractor options.
+        /// </param>
+        internal TimeSeriesExtractorContext(TimeSeriesExtractorOptions options) {
+            Options = options;
+
+            if (options.TimestampProperty != null) {
+                if (!JsonPointer.TryParse(options.TimestampProperty, out var timestampPointer)) {
+                    throw new ArgumentOutOfRangeException(nameof(options), string.Format(CultureInfo.CurrentCulture, Resources.Error_InvalidJsonPointer, options.TimestampProperty));
+                }
+                TimestampPointer = timestampPointer;
+            }
+            else {
+                TimestampPointer = null;
+            }
+
+            ElementStack = new Stack<KeyValuePair<string?, JsonElement>>();
+
+            // Assign to local variable first so that it can be referenced in the lambda
+            // expression below.
+            var timestampStack = Options.Recursive
+                ? Options.MaxDepth < 1
+                    ? new Stack<ParsedTimestamp>()
+                    : new Stack<ParsedTimestamp>(options.MaxDepth)
+                : new Stack<ParsedTimestamp>(1);
+
+            TimestampStack = timestampStack;
+
+            // We are using the default sample key template if:
+            //
+            // 1. We are running in recursive mode and the template is equal to TimeSeriesExtractor.FullPropertyNamePlaceholder.
+            // 2. We are running in non-recursive mode and the template is equal to TimeSeriesExtractor.FullPropertyNamePlaceholder
+            //    or TimeSeriesExtractor.LocalPropertyNamePlaceholder.
+            IsDefaultSampleKeyTemplate = Options.Recursive
+                ? string.Equals(Options.Template, TimeSeriesExtractor.FullPropertyNamePlaceholder, StringComparison.Ordinal)
+                : string.Equals(Options.Template, TimeSeriesExtractor.FullPropertyNamePlaceholder, StringComparison.Ordinal) || string.Equals(Options.Template, TimeSeriesExtractor.LocalPropertyNamePlaceholder, StringComparison.Ordinal);
+
+            IncludeElement = p => {
+                var ts = timestampStack.Peek();
+                if (ts.Pointer != null && p.Equals(ts.Pointer)) {
+                    return false;
+                }
+
+                // Lambdas declared in structs cannot reference instance members, so we need to
+                // use the constructor parameter for the options instead.
+                if (options.IncludeProperty != null && !options.IncludeProperty.Invoke(p)) {
+                    return false;
+                }
+
+                return true;
+            };
+        }
+
+    }
+}

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <RootNamespace>Jaahas.Json.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR contains breaking changes:

- `TimeSeriesExtractorOptions.IncludeProperty` signature has changed from `Func<string, bool>?` to `Func<JsonPointer, bool>?`.
- `TimeSeriesExtractorOptions.Template` can no longer be null or white space.
- `TimeSeriesExtractorOptions.PathSeparator`can no longer be null.
- `TimeSeriesExtractor` is now sealed.

Additional changes:

- When recursive mode is enabled, it is now possible to resolve the configured timestamp property relative to the current level of the JSON document, instead of against the document root only. This allows different objects within a document to define their own timestamp for extracted samples. This behaviour is controlled via the `TimeSeriesExtractorOptions.AllowNestedTimestamps` property. The default value of the property is `false`.
- When recursive mode is enabled, it is now possible to specify if array indexes should be included in the key that is generated for a given sample. This allows an array of samples (most likely with different timestamps) to return values using the same sample key. This behaviour us controlled via the `TimeSeriesExtractorOptions.IncludeArrayIndexesInSampleKeys` property. The default value of the property is `true` (i.e. the existing behaviour).
- Some internal changes to simplify private method signatures.
- Unit tests now run against .NET 8.0.