### PR TITLE
Use JsonPointer in TimeSeriesExtractorOptions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <NoWarn>NU1507;$(NoWarn)</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="JsonPointer.Net" Version="3.2.2" />
+    <PackageVersion Include="JsonPointer.Net" Version="3.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="JsonPointer.Net" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 0,
-  "Minor": 11,
+  "Minor": 12,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
+++ b/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>Jaahas.Json</RootNamespace>
     <AssemblyName>Jaahas.Json.TimeSeriesExtractor</AssemblyName>
     <Description>A library for parsing time series data samples from JSON documents using System.Text.Json</Description>

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
@@ -23,7 +23,7 @@ namespace Jaahas.Json {
         /// <returns>
         ///   A <see cref="Regex"/> instance.
         /// </returns>
-        [GeneratedRegex("@\"\\{(?<property>[^\\}]+?)\\}\"", RegexOptions.Singleline)]
+        [GeneratedRegex(@"\{(?<property>[^\}]+?)\}", RegexOptions.Singleline)]
         private static partial Regex GetSampleKeyTemplateMatcher();
 
 #else

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorConstants.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorConstants.cs
@@ -1,0 +1,41 @@
+﻿namespace Jaahas.Json {
+
+    /// <summary>
+    /// Constants for <see cref="TimeSeriesExtractorOptions"/> and <see cref="TimeSeriesExtractor"/>.
+    /// </summary>
+    public static class TimeSeriesExtractorConstants {
+
+        /// <summary>
+        /// <see cref="TimeSeriesExtractorOptions.Template"/> placeholder for the full JSON 
+        /// Pointer path to a property.
+        /// </summary>
+        public const string FullPropertyNamePlaceholder = "{$prop}";
+
+        /// <summary>
+        /// <see cref="TimeSeriesExtractorOptions.Template"/> placeholder for the local property 
+        /// name only.
+        /// </summary>
+        public const string LocalPropertyNamePlaceholder = "{$prop-local}";
+
+        /// <summary>
+        /// Default <see cref="TimeSeriesExtractorOptions.Template"/> value.
+        /// </summary>
+        public const string DefaultTemplate = FullPropertyNamePlaceholder;
+
+        /// <summary>
+        /// Default <see cref="TimeSeriesExtractorOptions.TimestampProperty"/> value.
+        /// </summary>
+        public const string DefaultTimestampProperty = "/time";
+
+        /// <summary>
+        /// Default <see cref="TimeSeriesExtractorOptions.PathSeparator"/> value.
+        /// </summary>
+        public const string DefaultPathSeparator = "/";
+
+        /// <summary>
+        /// Default <see cref="TimeSeriesExtractorOptions.MaxDepth"/> value.
+        /// </summary>
+        public const int DefaultMaxDepth = 5;
+
+    }
+}

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
@@ -13,34 +13,14 @@ namespace Jaahas.Json {
     public class TimeSeriesExtractorOptions : IValidatableObject {
 
         /// <summary>
-        /// Default <see cref="Template"/> value.
-        /// </summary>
-        public const string DefaultTemplate = TimeSeriesExtractor.FullPropertyNamePlaceholder;
-
-        /// <summary>
-        /// Default <see cref="TimestampProperty"/> value.
-        /// </summary>
-        public const string DefaultTimestampProperty = "/time";
-
-        /// <summary>
-        /// Default <see cref="PathSeparator"/> value.
-        /// </summary>
-        public const string DefaultPathSeparator = "/";
-
-        /// <summary>
-        /// Default <see cref="MaxDepth"/> value.
-        /// </summary>
-        public const int DefaultMaxDepth = 5;
-
-        /// <summary>
-        /// Specifies a JSON Pointer path that the <see cref="TimeSeriesExtractor"/> should start 
+        /// Specifies a JSON Pointer that the <see cref="TimeSeriesExtractor"/> should start 
         /// processing data from.
         /// </summary>
         /// <remarks>
-        ///   If <see cref="StartAt"/> is <see langword="null"/> or white space, processing will 
-        ///   start from the root of the JSON document.
+        ///   If <see cref="StartAt"/> is <see langword="null"/> start from the root of the JSON 
+        ///   document.
         /// </remarks>
-        public string? StartAt { get; set; }
+        public JsonPointer? StartAt { get; set; }
 
         /// <summary>
         /// The template to use when generating keys for extracted values.
@@ -48,7 +28,7 @@ namespace Jaahas.Json {
         /// <remarks>
         /// 
         /// <para>
-        ///   If <see cref="Template"/> is <see langword="null"/> or white space, <see cref="DefaultTemplate"/> 
+        ///   If <see cref="Template"/> is <see langword="null"/> or white space, <see cref="TimeSeriesExtractorConstants.DefaultTemplate"/> 
         ///   will be used.
         /// </para>
         ///   
@@ -89,7 +69,7 @@ namespace Jaahas.Json {
         /// </para>
         /// 
         /// </remarks>
-        public string Template { get; set; } = DefaultTemplate;
+        public string Template { get; set; } = TimeSeriesExtractorConstants.DefaultTemplate;
 
         /// <summary>
         /// A delegate that accepts a placeholder name referenced in the <see cref="Template"/> and
@@ -109,7 +89,7 @@ namespace Jaahas.Json {
         public bool AllowUnresolvedTemplateReplacements { get; set; } = true;
 
         /// <summary>
-        /// The JSON Pointer path to the property that defines the timestamp for the samples 
+        /// The JSON Pointer to the property that defines the timestamp for the samples 
         /// extracted from the JSON.
         /// </summary>
         /// <remarks>
@@ -130,7 +110,7 @@ namespace Jaahas.Json {
         /// 
         /// </remarks>
         /// <seealso cref="TimestampParser"/>
-        public string? TimestampProperty { get; set; } = DefaultTimestampProperty;
+        public JsonPointer? TimestampProperty { get; set; } = JsonPointer.Parse(TimeSeriesExtractorConstants.DefaultTimestampProperty);
 
         /// <summary>
         /// A delegate that overrides the default timestamp parser.
@@ -212,9 +192,15 @@ namespace Jaahas.Json {
         /// </para>
         /// 
         /// <para>
-        ///   When <see cref="IncludeProperty"/> is <see langword="null"/>, the default behaviour 
-        ///   is to emit a sample for every property except for the property identified as the 
-        ///   timestamp property.
+        ///   Samples are never emitted for timestamp properties , even if they are explicitly 
+        ///   included by <see cref="IncludeProperty"/>.
+        /// </para>
+        /// 
+        /// <para>
+        ///   <see cref="TimeSeriesExtractor.CreatePropertyMatcher(IEnumerable{JsonPointer}?, IEnumerable{JsonPointer}?)"/> 
+        ///   and <see cref="TimeSeriesExtractor.CreatePropertyMatcher(IEnumerable{string}?, IEnumerable{string}?)"/> 
+        ///   can be used to create a compatible delegate for <see cref="IncludeProperty"/> from 
+        ///   lists of JSON pointers to include and/or exclude.
         /// </para>
         /// 
         /// </remarks>
@@ -337,14 +323,14 @@ namespace Jaahas.Json {
         /// </para>
         /// 
         /// </remarks>
-        public int MaxDepth { get; set; } = DefaultMaxDepth;
+        public int MaxDepth { get; set; } = TimeSeriesExtractorConstants.DefaultMaxDepth;
 
         /// <summary>
         /// When <see cref="Recursive"/> is <see langword="true"/>, <see cref="PathSeparator"/> is 
         /// used to separate hierarchy levels when generating sample keys for nested objects and arrays.
         /// </summary>
         [Required]
-        public string PathSeparator { get; set; } = DefaultPathSeparator;
+        public string PathSeparator { get; set; } = TimeSeriesExtractorConstants.DefaultPathSeparator;
 
         /// <summary>
         /// When <see cref="Recursive"/> is <see langword="true"/>, setting <see cref="IncludeArrayIndexesInSampleKeys"/> 

--- a/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Jaahas.Json.Tests {
+
+    [TestClass]
+    public class ConfigurationBinderTests {
+
+        [TestMethod]
+        public void ShouldBindValidJsonPointer() {
+            var builder = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> {
+                    ["TimeSeriesExtractor:StartAt"] = "/foo/bar"
+                });
+
+            var config = builder.Build();
+
+            var options = new TimeSeriesExtractorOptions();
+            config.Bind("TimeSeriesExtractor", options);
+
+            Assert.IsNotNull(options.StartAt);
+            Assert.AreEqual("/foo/bar", options.StartAt.ToString());
+        }
+
+
+        [TestMethod]
+        public void ShouldNotBindInvalidJsonPointer() {
+            var builder = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> {
+                    ["TimeSeriesExtractor:StartAt"] = "invalid"
+                });
+
+            var config = builder.Build();
+
+            var options = new TimeSeriesExtractorOptions();
+            Assert.ThrowsException<InvalidOperationException>(() => config.Bind("TimeSeriesExtractor", options));
+        }
+
+    }
+
+}

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
@@ -486,7 +486,7 @@ namespace Jaahas.Json.Tests {
 
 
         [TestMethod]
-        public void ShoulAllowCustomTimestampParsing() {
+        public void ShouldAllowCustomTimestampParsing() {
             long secs = 1686559277;
 
             var deviceSample = new {

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
@@ -37,7 +37,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp)
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp))
             }).ToArray();
 
             Assert.AreEqual(13, samples.Length);
@@ -68,7 +68,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() { 
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp)
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp))
             }).ToArray();
 
             Assert.AreEqual(13, samples.Length);
@@ -100,7 +100,7 @@ namespace Jaahas.Json.Tests {
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Template = TestContext.TestName + "/{MacAddress}/{$prop}",
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp),
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
             }).ToArray();
 
             Assert.AreEqual(13, samples.Length);
@@ -134,7 +134,7 @@ namespace Jaahas.Json.Tests {
             var guid = Guid.NewGuid();
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Template = TestContext.TestName + "/{MacAddress}/{Uuid}/{$prop}",
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp),
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 GetTemplateReplacement = text => { 
                     switch (text.ToUpperInvariant()) {
                         case "UUID":
@@ -175,7 +175,7 @@ namespace Jaahas.Json.Tests {
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Template = TestContext.TestName + "/{MacAddress}/{DataFormat}/{$prop}",
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp),
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 IncludeProperty = prop => {
                     if (prop.ToString().Equals("/" + nameof(deviceSample.DataFormat))) {
                         return false;
@@ -217,7 +217,7 @@ namespace Jaahas.Json.Tests {
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Template = TestContext.TestName + "/{MacAddress}/{DataFormat}/{$prop}",
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp),
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 IncludeProperty = prop => {
                     if (prop.ToString().Equals("/" + nameof(deviceSample.Temperature))) {
                         return true;
@@ -304,7 +304,7 @@ namespace Jaahas.Json.Tests {
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Template = TestContext.TestName + "/{$prop}",
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp),
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 Recursive = true
             }).ToArray();
 
@@ -474,7 +474,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp)
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp))
             }).ToArray();
 
             Assert.AreEqual(13, samples.Length);
@@ -509,7 +509,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                TimestampProperty = "/" + nameof(deviceSample.Timestamp),
+                TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 TimestampParser = element => new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(element.GetInt64())
             }).ToArray();
 
@@ -549,7 +549,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                StartAt = "/data",
+                StartAt = JsonPointer.Parse("/data"),
                 Recursive = true
             }).ToArray();
 


### PR DESCRIPTION
## Breaking Changes

- The type of both `TimeSeriesExtractorOptions.StartAt` and `TimeSeriesExtractorOptions.TimestampProperty` has changed from `string?` to `JsonPointer?`, as JsonPointer.Net 3.3.0 adds support for binding an `IConfiguration` to a `JsonPointer`. Use `JsonPointer.Parse(string)` to create `JsonPointer` instances when creation `TimeSeriesExtractorOptions` manually.
- Constants that were previously defined in `TimeSeriesExtractorOptions` and `TimeSeriesExtractor` have been moved to a new `TimeSeriesExtractorConstants` class.

## Additional Changes

- New `CreatePropertyMatcher` methods have been added to `TimeSeriesExtractor` to simplify creating a delegate for use with `TimeSeriesExtractorOptions.IncludeProperty` when you have a known list of properties to include and/or exclude. 