### PR TITLE
Match rule improvements

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 0,
-  "Minor": 14,
+  "Major": 1,
+  "Minor":0,
   "Patch": 0,
-  "PreRelease": ""
+  "PreRelease": "preview.1"
 }

--- a/samples/JsonTimeSeriesExtractor.Cli/Program.cs
+++ b/samples/JsonTimeSeriesExtractor.Cli/Program.cs
@@ -13,14 +13,22 @@ using (var stream = new FileStream("data.json", FileMode.Open)) {
     json = await JsonSerializer.DeserializeAsync<JsonElement>(stream, jsonOptions);
 }
 
-var options = new TimeSeriesExtractorOptions() { 
-    AllowNestedTimestamps = true,
-    IncludeArrayIndexesInSampleKeys = false,
-    IncludeProperty = p => !p.Segments.Last().Value.Equals("t"),
-    MaxDepth = 5,
+var options = new TimeSeriesExtractorOptions() {
+    // We want to extract samples from nested objects.
     Recursive = true,
-    StartAt = JsonPointer.Parse("/body/data"),
-    TimestampProperty = JsonPointer.Parse("/ts"),
+    // Our JSON contains an array of samples, each with its own timestamp.
+    AllowNestedTimestamps = true,
+    // The timestamp is located at the "ts" property on each sample object.
+    TimestampProperty = "/ts",
+    // Each object in the samples array contains a "v" property with the sample value. We'll use
+    // an MQTT-style match expression to extract values from the "v" property on each object in
+    // the array
+    CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
+        PointersToInclude = ["/body/data/+/v"],
+        AllowWildcardExpressions = true
+    }),
+    // Each object in the samples array contains a "t" property with the name of the instrument
+    // for the sample. We'll use this as the key when emitting a sample.
     Template = "{t}"
 };
 

--- a/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+using Json.Pointer;
+
+namespace Jaahas.Json {
+
+    /// <summary>
+    /// Represents a JSON Pointer that is created from a <see cref="JsonPointer"/> instance or a 
+    /// literal string.
+    /// </summary>
+    [TypeConverter(typeof(JsonPointerLiteralTypeConverter))]
+    public sealed class JsonPointerLiteral {
+
+        /// <summary>
+        /// The JSON Pointer.
+        /// </summary>
+        public JsonPointer Pointer { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonPointerLiteral"/> instance using a JSON Pointer.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        public JsonPointerLiteral(JsonPointer pointer) {
+            Pointer = pointer ?? throw new ArgumentNullException(nameof(pointer));
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonPointerLiteral"/> instance using a JSON Pointer literal.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The pointer literal.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="PointerParseException">
+        ///   <paramref name="pointer"/> is not a valid JSON Pointer.
+        /// </exception>
+        public JsonPointerLiteral(string pointer) {
+            if (pointer == null) {
+                throw new ArgumentNullException(nameof(pointer));
+            }
+
+            Pointer = JsonPointer.Parse(pointer);
+        }
+
+
+        /// <summary>
+        /// Tries to create a new <see cref="JsonPointerLiteral"/> from a string.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer string.
+        /// </param>
+        /// <param name="result">
+        ///   The resulting <see cref="JsonPointerLiteral"/> instance, or <see langword="null"/> 
+        ///   if parsing is unsuccessful.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the string was successfully parsed; otherwise, 
+        ///   <see langword="false"/>.
+        /// </returns>
+        public static bool TryParse(
+            string? pointer,
+#if NETCOREAPP
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+#endif
+            out JsonPointerLiteral? result
+        ) {
+            if (pointer == null) {
+                result = null;
+                return false;
+            }
+
+            if (JsonPointer.TryParse(pointer, out var jsonPointer)) {
+                result = new JsonPointerLiteral(jsonPointer);
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+
+        /// <inheritdoc />
+        public override int GetHashCode() => Pointer.GetHashCode();
+
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => obj is JsonPointerLiteral other
+            ? Pointer.Equals(other.Pointer)
+            : Pointer.Equals(obj);
+
+
+        /// <inheritdoc />
+        public override string ToString() => Pointer.ToString();
+
+
+        /// <summary>
+        /// Converts a <see cref="JsonPointerLiteral"/> to a <see cref="JsonPointer"/>.
+        /// </summary>
+        /// <param name="literal">
+        ///   The JSON Pointer literal.
+        /// </param>
+        public static implicit operator JsonPointer(JsonPointerLiteral literal) => literal.Pointer;
+
+
+        /// <summary>
+        /// Converts a <see cref="JsonPointer"/> to a <see cref="JsonPointerLiteral"/>.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        public static implicit operator JsonPointerLiteral(JsonPointer pointer) => new JsonPointerLiteral(pointer);
+
+
+        /// <summary>
+        /// Converts a <see cref="string"/> to a <see cref="JsonPointerLiteral"/>.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer literal.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="PointerParseException">
+        ///   <paramref name="pointer"/> is not a valid JSON Pointer.
+        /// </exception>
+        public static implicit operator JsonPointerLiteral(string pointer) => new JsonPointerLiteral(pointer);
+
+
+        /// <summary>
+        /// <see cref="TypeConverter"/> for <see cref="JsonPointerLiteral"/>.
+        /// </summary>
+        public sealed class JsonPointerLiteralTypeConverter : TypeConverter {
+
+            /// <inheritdoc />
+            public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) {
+                return sourceType == typeof(string) || sourceType == typeof(JsonPointer) || sourceType == typeof(JsonPointerLiteral);
+            }
+
+
+            /// <inheritdoc />
+            public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) {
+                return destinationType == typeof(string) || destinationType == typeof(JsonPointer) || destinationType == typeof(JsonPointerLiteral);
+            }
+
+
+            /// <inheritdoc />
+            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value) {
+                if (value is string s) {
+                    return new JsonPointerLiteral(s);
+                }
+                else if (value is JsonPointer pointer) {
+                    return new JsonPointerLiteral(pointer);
+                }
+                else if (value is JsonPointerLiteral literal) {
+                    return literal;
+                }
+
+                return base.ConvertFrom(context, culture, value);
+            }
+
+
+            /// <inheritdoc />
+            public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType) {
+                if (destinationType == typeof(string)) {
+                    return value?.ToString()!;
+                }
+                else if (destinationType == typeof(JsonPointer) && value is JsonPointerLiteral pointerLiteral) {
+                    return pointerLiteral.Pointer;
+                }
+                else if (destinationType == typeof(JsonPointerLiteral)) {
+                    return value;
+                }
+
+                return base.ConvertTo(context, culture, value, destinationType);
+            }
+
+        }
+
+    }
+}

--- a/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+using Json.Pointer;
+
+namespace Jaahas.Json {
+
+    /// <summary>
+    /// <see cref="JsonPointerMatch"/> describes a rule for matching JSON Pointer paths.
+    /// </summary>
+    [TypeConverter(typeof(JsonPointerMatchTypeConverter))]
+    public sealed class JsonPointerMatch {
+
+        /// <summary>
+        /// The JSON Pointer for the rule, if a valid JSON Pointer was specified when creating the 
+        /// <see cref="JsonPointerMatch"/> instance.
+        /// </summary>
+        /// <remarks>
+        ///   <see cref="Pointer"/> will be <see langword="null"/> when <see cref="RawValue"/> is 
+        ///   a pattern matching expression that is not a syntactically valid JSON Pointer.  
+        /// </remarks>
+        public JsonPointer? Pointer { get; }
+
+        /// <summary>
+        /// The raw value of the JSON Pointer or pattern match expression.
+        /// </summary>
+        public string RawValue { get; } = default!;
+
+        /// <summary>
+        /// Specifies if <see cref="RawValue"/> contains a single-character pattern match wildcard.
+        /// </summary>
+        private readonly bool _containsSingleCharacterPatternWildcard;
+
+        /// <summary>
+        /// Specifies if <see cref="RawValue"/> contains a multi-character pattern match wildcard.
+        /// </summary>
+        private readonly bool _containsMultiCharacterPatternWildcard;
+
+        /// <summary>
+        /// Specifies if <see cref="Pointer"/> contains any segments that are single-level MQTT 
+        /// wildcards.
+        /// </summary>
+        private readonly bool _containsSingleLevelMqttWildcardSegment;
+
+        /// <summary>
+        /// Specifies if <see cref="Pointer"/> contains a final segments that is a multi-level 
+        /// MQTT wildcard.
+        /// </summary>
+        private readonly bool _containsMultiLevelMqttWildcardSegment;
+
+
+        /// <summary>
+        /// Specifies if the <see cref="JsonPointerMatch"/> instance represents a pattern match or 
+        /// MQTT-style wildcard match rule.
+        /// </summary>
+        public bool IsWildcardMatchRule => IsPatternWildcardMatchRule || IsMqttWildcardMatchRule;
+
+        /// <summary>
+        /// Specifies if the <see cref="JsonPointerMatch"/> instance represents a pattern match rule.
+        /// </summary>
+        public bool IsPatternWildcardMatchRule => _containsSingleCharacterPatternWildcard || _containsMultiCharacterPatternWildcard;
+
+        /// <summary>
+        /// Specifies if the <see cref="JsonPointerMatch"/> instance represents an MQTT-style 
+        /// wildcard match rule.
+        /// </summary>
+        public bool IsMqttWildcardMatchRule => _containsSingleLevelMqttWildcardSegment || _containsMultiLevelMqttWildcardSegment;
+
+        
+        /// <summary>
+        /// Creates a new <see cref="JsonPointerMatch"/> instance.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer.
+        /// </param>
+        /// <param name="throwOnNull">
+        ///   When <see langword="true"/>, an exception will be thrown if <paramref name="pointer"/> 
+        ///   is <see langword="null"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/> and <paramref name="throwOnNull"/> 
+        ///   is <see langword="true"/>.
+        /// </exception>
+        private JsonPointerMatch(JsonPointer? pointer, bool throwOnNull) {
+            if (pointer == null && throwOnNull) {
+                throw new ArgumentNullException(nameof(pointer));
+            }
+
+            Pointer = pointer;
+            
+            if (Pointer != null) {
+                RawValue = Pointer.ToString();
+
+                foreach (var segment in Pointer.Segments) {
+                    if (segment.Value.Equals(TimeSeriesExtractor.SingleLevelMqttWildcard, StringComparison.Ordinal)) {
+                        _containsSingleLevelMqttWildcardSegment = true;
+                    }
+                    else if (segment.Value.Equals(TimeSeriesExtractor.MultiLevelMqttWildcard, StringComparison.Ordinal) && segment.Equals(Pointer.Segments[Pointer.Segments.Length - 1])) {
+                        _containsMultiLevelMqttWildcardSegment = true;
+                    }
+                    else if (segment.Value.Contains(TimeSeriesExtractor.SingleCharacterWildcard)) {
+                        _containsSingleCharacterPatternWildcard = true;
+                    }
+                    else if (segment.Value.Contains(TimeSeriesExtractor.MultiCharacterWildcard)) {
+                        _containsMultiCharacterPatternWildcard = true;
+                    }
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonPointerMatch"/> instance using the specified JSON 
+        /// Pointer.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        public JsonPointerMatch(JsonPointer pointer) : this(pointer, true) { }
+
+
+        /// <summary>
+        /// Creates a new <see cref="JsonPointerMatch"/> instance using the specified pointer 
+        /// literal or pattern wildcard expression.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer literal or pattern wildcard expression.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="pointer"/> is not a valid JSON Pointer or 
+        ///   pattern wildcard expression.
+        /// </exception>
+        public JsonPointerMatch(string pointer) : this(JsonPointer.TryParse(pointer, out var p) ? p : null, false) {
+            if (Pointer == null && pointer != null) {
+                RawValue = pointer;
+
+                if (pointer.Contains(TimeSeriesExtractor.SingleCharacterWildcard)) {
+                    _containsSingleCharacterPatternWildcard = true;
+                }
+                if (pointer.Contains(TimeSeriesExtractor.MultiCharacterWildcard)) {
+                    _containsMultiCharacterPatternWildcard = true;
+                }
+            }
+            
+            // If we haven't been given a valid pointer, we'll throw an exception unless the
+            // pointer string is a pattern expression
+            if (Pointer == null && !IsPatternWildcardMatchRule) {
+                throw new ArgumentException(string.Format(Resources.Error_NotAValidJsonPointerOrPatternExpression, pointer), nameof(pointer));
+            }
+        }
+
+
+        /// <summary>
+        /// Tries to create a new <see cref="JsonPointerMatch"/> from a string.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer string.
+        /// </param>
+        /// <param name="result">
+        ///   The resulting <see cref="JsonPointerMatch"/> instance, or <see langword="null"/> 
+        ///   if parsing is unsuccessful.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the string was successfully parsed; otherwise, 
+        ///   <see langword="false"/>.
+        /// </returns>
+        public static bool TryParse(
+            string? pointer,
+#if NETCOREAPP
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+#endif
+            out JsonPointerMatch? result
+        ) {
+            if (pointer == null) {
+                result = null;
+                return false;
+            }
+
+            try {
+                result = new JsonPointerMatch(pointer);
+                return true;
+            }
+            catch {
+                result = null;
+                return false;
+            }
+        }
+
+
+        /// <inheritdoc />
+        public override string ToString() => RawValue ?? Pointer!.ToString();
+
+
+        /// <summary>
+        /// Converts a <see cref="JsonPointer"/> to a <see cref="JsonPointerMatch"/>.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        public static implicit operator JsonPointerMatch(JsonPointer pointer) => new JsonPointerMatch(pointer);
+
+
+        /// <summary>
+        /// Converts a <see cref="string"/> to a <see cref="JsonPointerMatch"/>.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer literal.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="pointer"/> is not a valid JSON Pointer or a pattern match wildcard 
+        ///   expression.
+        /// </exception>
+        public static implicit operator JsonPointerMatch(string pointer) => new JsonPointerMatch(pointer);
+
+
+        /// <summary>
+        /// <see cref="TypeConverter"/> for <see cref="JsonPointerMatch"/>.
+        /// </summary>
+        public sealed class JsonPointerMatchTypeConverter : TypeConverter {
+
+            /// <inheritdoc />
+            public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) {
+                return sourceType == typeof(string) || sourceType == typeof(JsonPointer) || sourceType == typeof(JsonPointerMatch);
+            }
+
+
+            /// <inheritdoc />
+            public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) {
+                return destinationType == typeof(string) || destinationType == typeof(JsonPointerMatch);
+            }
+
+
+            /// <inheritdoc />
+            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value) {
+                if (value is string s) {
+                    return new JsonPointerMatch(s);
+                }
+                else if (value is JsonPointer pointer) {
+                    return new JsonPointerMatch(pointer);
+                }
+                else if (value is JsonPointerMatch match) {
+                    return match;
+                }
+
+                return base.ConvertFrom(context, culture, value);
+            }
+
+
+            /// <inheritdoc />
+            public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType) {
+                if (destinationType == typeof(string)) {
+                    return value?.ToString()!;
+                }
+                else if (destinationType == typeof(JsonPointerMatch)) {
+                    return value;
+                }
+
+                return base.ConvertTo(context, culture, value, destinationType);
+            }
+
+        }
+
+    }
+}

--- a/src/JsonTimeSeriesExtractor/JsonPointerMatchDelegate.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerMatchDelegate.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+
+using Json.Pointer;
+
+namespace Jaahas.Json {
+
+    /// <summary>
+    /// A delegate that can be used to test if <see cref="TimeSeriesExtractor"/> should process a 
+    /// JSON element.
+    /// </summary>
+    /// <param name="context">
+    ///   The time series extractor context.
+    /// </param>
+    /// <param name="pointer">
+    ///   The JSON pointer to the element.
+    /// </param>
+    /// <param name="element">
+    ///   The JSON element.
+    /// </param>
+    /// <returns>
+    ///   <see langword="true"/> if the element should be processed; otherwise, <see langword="false"/>.
+    /// </returns>
+    public delegate bool JsonPointerMatchDelegate(TimeSeriesExtractorContext context, JsonPointer pointer, JsonElement element);
+
+}

--- a/src/JsonTimeSeriesExtractor/JsonPointerMatchDelegateOptions.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerMatchDelegateOptions.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+
+namespace Jaahas.Json {
+
+    /// <summary>
+    /// Options when creating delegates for matching JSON Pointer paths.
+    /// </summary>
+    public class JsonPointerMatchDelegateOptions {
+
+        /// <summary>
+        /// The JSON pointers to match.
+        /// </summary>
+        /// <remarks>
+        ///   If not <see langword="null"/>, only pointers in a JSON document that match an entry 
+        ///   in this list will be processed. Otherwise, pointers will be processed unless they 
+        ///   match an entry in <paramref name="PointersToExclude"/>.
+        /// </remarks>
+        public IEnumerable<JsonPointerMatch>? PointersToInclude { get; set; }
+
+        /// <summary>
+        /// The JSON pointers to exclude.
+        /// </summary>
+        /// <remarks>
+        ///   If not <see langword="null"/>, pointers in a JSON document that match an entry in 
+        ///   this list will always be excluded.
+        /// </remarks>
+        public IEnumerable<JsonPointerMatch>? PointersToExclude { get; set; }
+
+        /// <summary>
+        /// Specifies if entries in <see cref="PointersToInclude"/> and <see cref="PointersToExclude"/> 
+        /// containing known wildcard characters should be treated as wildcard expressions instead 
+        /// of literal paths.
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   When wildcard patterns are enabled, pointer match rules can specify either pattern 
+        ///   match wildcards (i.e. <c>?</c> for a single-character wildcard, and <c>*</c> for a 
+        ///   multi-character wildcard), or MQTT-style wildcard characters (i.e. <c>+</c> for a 
+        ///   single-level wildcard, and <c>#</c> for a multi-level wildcard).
+        /// </para>
+        /// 
+        /// <para>
+        ///   The two matching styles are mutually exclusive; if a pointer path contains single- 
+        ///   or multi-character wildcard characters the path is assumed to be a pattern match, 
+        ///   and MQTT-style wildcards are treated as literal characters. For example, 
+        ///   <c>/foo/+/bar</c> is treated as an MQTT-style match, but <c>/foo/+/*</c> is treated 
+        ///   as a regular pattern match.
+        /// </para>
+        /// 
+        /// <para>
+        ///   In an MQTT-style match expression, the multi-level wildcard character is only valid 
+        ///   in the final segment of the pointer path. For example, <c>/foo/bar/#</c> is a valid 
+        ///   MQTT match expression, but <c>/foo/#/bar</c> is not.
+        /// </para>
+        /// 
+        /// <para>
+        ///   In an MQTT-style match expression, you cannot specify both wildcard and non-wildcard 
+        ///   characters in the same pointer segment. For example, <c>/foo/bar+/baz</c> is not a 
+        ///   valid MQTT match expression and will be interpreted as a literal JSON Pointer path.
+        /// </para>
+        /// 
+        /// </remarks>
+        public bool AllowWildcardExpressions { get; set; }
+
+        /// <summary>
+        /// Specifies if pattern match expressions should use the <see cref="System.Text.RegularExpressions.RegexOptions.Compiled"/> 
+        /// flag when creating their underlying regular expressions.
+        /// </summary>
+        /// <remarks>
+        ///   Compiled regular expressions are enabled by default.
+        /// </remarks>
+        public bool UseCompiledRegularExpressions { get; set; } = true;
+
+    }
+}

--- a/src/JsonTimeSeriesExtractor/JsonPointerMatchDelegateOptions.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerMatchDelegateOptions.cs
@@ -41,6 +41,13 @@ namespace Jaahas.Json {
         /// </para>
         /// 
         /// <para>
+        ///   MQTT-stye match expressions must always be valid JSON Pointers. Pattern match 
+        ///   expressions do not have to be valid JSON Pointers, but will be ignored if 
+        ///   <see cref="AllowWildcardExpressions"/> is <see langword="false"/> if they are not 
+        ///   valid JSON Pointers.
+        /// </para>
+        /// 
+        /// <para>
         ///   The two matching styles are mutually exclusive; if a pointer path contains single- 
         ///   or multi-character wildcard characters the path is assumed to be a pattern match, 
         ///   and MQTT-style wildcards are treated as literal characters. For example, 

--- a/src/JsonTimeSeriesExtractor/Resources.Designer.cs
+++ b/src/JsonTimeSeriesExtractor/Resources.Designer.cs
@@ -61,11 +61,11 @@ namespace Jaahas.Json {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid JSON pointer..
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid JSON pointer or wildcard pattern expression.
         /// </summary>
-        internal static string Error_InvalidJsonPointer {
+        internal static string Error_NotAValidJsonPointerOrPatternExpression {
             get {
-                return ResourceManager.GetString("Error_InvalidJsonPointer", resourceCulture);
+                return ResourceManager.GetString("Error_NotAValidJsonPointerOrPatternExpression", resourceCulture);
             }
         }
         

--- a/src/JsonTimeSeriesExtractor/Resources.resx
+++ b/src/JsonTimeSeriesExtractor/Resources.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Error_InvalidJsonPointer" xml:space="preserve">
-    <value>'{0}' is not a valid JSON pointer.</value>
+  <data name="Error_NotAValidJsonPointerOrPatternExpression" xml:space="preserve">
+    <value>'{0}' is not a valid JSON pointer or wildcard pattern expression</value>
     <comment>{0} - invalid pointer</comment>
   </data>
   <data name="Error_UnresolvedTemplateParameter" xml:space="preserve">

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
@@ -20,7 +20,7 @@ namespace Jaahas.Json {
         ///   If <see cref="StartAt"/> is <see langword="null"/> start from the root of the JSON 
         ///   document.
         /// </remarks>
-        public JsonPointer? StartAt { get; set; }
+        public JsonPointerLiteral? StartAt { get; set; }
 
         /// <summary>
         /// The template to use when generating keys for extracted values.
@@ -110,7 +110,7 @@ namespace Jaahas.Json {
         /// 
         /// </remarks>
         /// <seealso cref="TimestampParser"/>
-        public JsonPointer? TimestampProperty { get; set; } = JsonPointer.Parse(TimeSeriesExtractorConstants.DefaultTimestampProperty);
+        public JsonPointerLiteral? TimestampProperty { get; set; } = JsonPointer.Parse(TimeSeriesExtractorConstants.DefaultTimestampProperty);
 
         /// <summary>
         /// A delegate that overrides the default timestamp parser.
@@ -182,29 +182,10 @@ namespace Jaahas.Json {
         public bool AllowNestedTimestamps { get; set; }
 
         /// <summary>
-        /// A delegate that is used to determine if a sample should be emitted for a given 
-        /// JSON property.
+        /// A delegate that is used to determine if a JSON element should be processed by the time 
+        /// series extractor.
         /// </summary>
-        /// <remarks>
-        /// 
-        /// <para>
-        ///   The parameter passed to the delegate is the JSON pointer path for the property.
-        /// </para>
-        /// 
-        /// <para>
-        ///   Samples are never emitted for timestamp properties , even if they are explicitly 
-        ///   included by <see cref="IncludeProperty"/>.
-        /// </para>
-        /// 
-        /// <para>
-        ///   <see cref="TimeSeriesExtractor.CreatePropertyMatcher(IEnumerable{JsonPointer}?, IEnumerable{JsonPointer}?)"/> 
-        ///   and <see cref="TimeSeriesExtractor.CreatePropertyMatcher(IEnumerable{string}?, IEnumerable{string}?)"/> 
-        ///   can be used to create a compatible delegate for <see cref="IncludeProperty"/> from 
-        ///   lists of JSON pointers to include and/or exclude.
-        /// </para>
-        /// 
-        /// </remarks>
-        public Func<JsonPointer, bool>? IncludeProperty { get; set; }
+        public JsonPointerMatchDelegate? CanProcessElement { get; set; } 
 
         /// <summary>
         /// When <see langword="true"/>, JSON properties that contain other objects or arrays will 
@@ -404,10 +385,10 @@ namespace Jaahas.Json {
 
             AllowNestedTimestamps = existing.AllowNestedTimestamps;
             AllowUnresolvedTemplateReplacements = existing.AllowUnresolvedTemplateReplacements;
+            CanProcessElement = existing.CanProcessElement;
             GetDefaultTimestamp = existing.GetDefaultTimestamp;
             GetTemplateReplacement = existing.GetTemplateReplacement;
             IncludeArrayIndexesInSampleKeys = existing.IncludeArrayIndexesInSampleKeys;
-            IncludeProperty = existing.IncludeProperty;
             MaxDepth = existing.MaxDepth;
             PathSeparator = existing.PathSeparator;
             Recursive = existing.Recursive;

--- a/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
@@ -39,6 +39,71 @@ namespace Jaahas.Json.Tests {
             Assert.ThrowsException<InvalidOperationException>(() => config.Bind("TimeSeriesExtractor", options));
         }
 
+
+        [TestMethod]
+        public void ShouldBindValidJsonPointerLiteralMatch() {
+            var builder = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> {
+                    ["JsonPointerMatch:Match"] = "/foo/bar"
+                });
+
+            var config = builder.Build();
+
+            var options = new JsonPointerMatchOptions();
+            config.Bind("JsonPointerMatch", options);
+
+            Assert.IsNotNull(options.Match);
+            Assert.AreEqual("/foo/bar", options.Match.ToString());
+            Assert.IsFalse(options.Match.IsWildcardMatchRule);
+        }
+
+
+        [TestMethod]
+        public void ShouldBindValidJsonPointerMqttMatch() {
+            var builder = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> {
+                    ["JsonPointerMatch:Match"] = "/foo/bar/+/baz/#"
+                });
+
+            var config = builder.Build();
+
+            var options = new JsonPointerMatchOptions();
+            config.Bind("JsonPointerMatch", options);
+
+            Assert.IsNotNull(options.Match);
+            Assert.AreEqual("/foo/bar/+/baz/#", options.Match.ToString());
+            Assert.IsTrue(options.Match.IsWildcardMatchRule);
+            Assert.IsFalse(options.Match.IsPatternWildcardMatchRule);
+            Assert.IsTrue(options.Match.IsMqttWildcardMatchRule);
+        }
+
+
+        [TestMethod]
+        public void ShouldBindValidJsonPointerPatternMatch() {
+            var builder = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> {
+                    ["JsonPointerMatch:Match"] = "*/bar"
+                });
+
+            var config = builder.Build();
+
+            var options = new JsonPointerMatchOptions();
+            config.Bind("JsonPointerMatch", options);
+
+            Assert.IsNotNull(options.Match);
+            Assert.AreEqual("*/bar", options.Match.ToString());
+            Assert.IsTrue(options.Match.IsWildcardMatchRule);
+            Assert.IsTrue(options.Match.IsPatternWildcardMatchRule);
+            Assert.IsFalse(options.Match.IsMqttWildcardMatchRule);
+        }
+
+
+        private class JsonPointerMatchOptions {
+            
+            public JsonPointerMatch? Match { get; set; }
+
+        }
+
     }
 
 }

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
@@ -175,9 +175,11 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Template = TestContext.TestName + "/{MacAddress}/{DataFormat}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
-                IncludeProperty = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(null, new[] {
-                    $"/{nameof(deviceSample.DataFormat)}",
-                    $"/{nameof(deviceSample.MacAddress)}"
+                CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
+                    PointersToExclude = new JsonPointerMatch[] {
+                        $"/{nameof(deviceSample.DataFormat)}",
+                        $"/{nameof(deviceSample.MacAddress)}"
+                    }
                 })
             }).ToArray();
 
@@ -212,11 +214,13 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Template = TestContext.TestName + "/{MacAddress}/{DataFormat}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
-                IncludeProperty = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new[] {
-                    $"/{nameof(deviceSample.Temperature)}",
-                    $"/{nameof(deviceSample.Humidity)}",
-                    $"/{nameof(deviceSample.Pressure)}"
-                }, null)
+                CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() {
+                    PointersToInclude = new JsonPointerMatch[] {
+                        $"/{nameof(deviceSample.Temperature)}",
+                        $"/{nameof(deviceSample.Humidity)}",
+                        $"/{nameof(deviceSample.Pressure)}"
+                    }
+                })
             }).ToArray();
 
             Assert.AreEqual(3, samples.Length);
@@ -254,9 +258,12 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Recursive = true,
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
-                IncludeProperty = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new[] {
-                    $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/#",
-                }, null, allowWildcards: true)
+                CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
+                    AllowWildcardExpressions = true,
+                    PointersToInclude = new JsonPointerMatch[] {
+                        $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/#",
+                    }
+                })
             }).ToArray();
 
             Assert.AreEqual(3, samples.Length);
@@ -294,9 +301,12 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Recursive = true,
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
-                IncludeProperty = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new[] {
-                    $"/+/+/X",
-                }, null, allowWildcards: true)
+                CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
+                    AllowWildcardExpressions = true,
+                    PointersToInclude = new JsonPointerMatch[] {
+                        $"/+/+/X",
+                    }
+                })
             }).ToArray();
 
             Assert.AreEqual(1, samples.Length);
@@ -336,9 +346,12 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Recursive = true,
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
-                IncludeProperty = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new[] {
-                    $"/*/X",
-                }, null, allowWildcards: true)
+                CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
+                    AllowWildcardExpressions = true,
+                    PointersToInclude = new JsonPointerMatch[] {
+                        "*/X",
+                    }
+                })
             }).ToArray();
 
             Assert.AreEqual(1, samples.Length);
@@ -378,9 +391,12 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Recursive = true,
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
-                IncludeProperty = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new[] {
-                    $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/?",
-                }, null, allowWildcards: true)
+                CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
+                    AllowWildcardExpressions = true,
+                    PointersToInclude = new JsonPointerMatch[] {
+                        $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/?",
+                    }
+                })
             }).ToArray();
 
             Assert.AreEqual(3, samples.Length);
@@ -481,7 +497,7 @@ namespace Jaahas.Json.Tests {
                 Template = "{location}/{$prop}",
                 PathSeparator = "/",
                 Recursive = true,
-                IncludeProperty = prop => !prop.Segments.Last().Value.Equals("location")
+                CanProcessElement = (_, prop, _) => !prop.Segments.Last().Value.Equals("location")
             }).ToArray();
 
             Assert.AreEqual(1, samples.Length);
@@ -506,7 +522,7 @@ namespace Jaahas.Json.Tests {
                 Template = "{location}/{$prop-local}",
                 PathSeparator = "/",
                 Recursive = true,
-                IncludeProperty = prop => !prop.Segments.Last().Value.Equals("location")
+                CanProcessElement = (_, prop, _) => !prop.Segments.Last().Value.Equals("location")
             }).ToArray();
 
             Assert.AreEqual(1, samples.Length);


### PR DESCRIPTION
This PR makes the following changes:

## Breaking changes

* The type of the `TimeSeriesExtractorOptions.StartAt` property is now `JsonPointerLiteral?` instead of `JsonPointer?`.
* The type of the `TimeSeriesExtractorOptions.TimestampProperty` property is now `JsonPointerLiteral?` instead of `JsonPointer?`.
* The `TimeSeriesExtractorOptions.IncludeProperty` property has been replaced with a new `CanProcessElement` property. The type of the new property is `JsonPointerMatchDelegate`.
* The existing overloads for `TimeSeriesExtractor.CreateJsonPointerMatchDelegate` have been removed and replaced with a new overload that accepts a `JsonPointerMatchDelegateOptions` object. This makes it easier to managed the desired behaviour of the generated delegate.

## Other changes

* Match rules that use pattern match expressions (i.e. `*` and `?` for multi- and single-character wildcards respectively) no longer have to be valid JSON pointers.
* When creating a delegate using `TimeSeriesExtractor.CreateJsonPointerMatchDelegate`, the options can specify if compiled regexes should be used when parsing pattern match rules.