### PR TITLE
Implicit operators allow null values

### DIFF
--- a/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
@@ -90,6 +90,24 @@ namespace Jaahas.Json {
         }
 
 
+        /// <summary>
+        /// Creates a new <see cref="JsonPointerLiteral"/> from a string.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer string.
+        /// </param>
+        /// <returns>
+        ///   The resulting <see cref="JsonPointerLiteral"/> instance.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pointer"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="PointerParseException">
+        ///   <paramref name="pointer"/> is not a valid JSON Pointer.
+        /// </exception>
+        public static JsonPointerLiteral Parse(string pointer) => new JsonPointerLiteral(pointer);
+
+
         /// <inheritdoc />
         public override int GetHashCode() => Pointer.GetHashCode();
 
@@ -119,10 +137,7 @@ namespace Jaahas.Json {
         /// <param name="pointer">
         ///   The JSON Pointer.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="pointer"/> is <see langword="null"/>.
-        /// </exception>
-        public static implicit operator JsonPointerLiteral(JsonPointer pointer) => new JsonPointerLiteral(pointer);
+        public static implicit operator JsonPointerLiteral(JsonPointer pointer) => pointer == null ? null! : new JsonPointerLiteral(pointer);
 
 
         /// <summary>
@@ -131,13 +146,10 @@ namespace Jaahas.Json {
         /// <param name="pointer">
         ///   The JSON Pointer literal.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="pointer"/> is <see langword="null"/>.
-        /// </exception>
         /// <exception cref="PointerParseException">
         ///   <paramref name="pointer"/> is not a valid JSON Pointer.
         /// </exception>
-        public static implicit operator JsonPointerLiteral(string pointer) => new JsonPointerLiteral(pointer);
+        public static implicit operator JsonPointerLiteral(string pointer) => pointer == null ? null! : new JsonPointerLiteral(pointer);
 
 
         /// <summary>

--- a/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
@@ -191,6 +191,22 @@ namespace Jaahas.Json {
         }
 
 
+        /// <summary>
+        /// Creates a new <see cref="JsonPointerMatch"/> from a string.
+        /// </summary>
+        /// <param name="pointer">
+        ///   The JSON Pointer string.
+        /// </param>
+        /// <returns>
+        ///   The resulting <see cref="JsonPointerMatch"/> instance.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="pointer"/> is not a valid JSON Pointer or 
+        ///   pattern wildcard expression.
+        /// </exception>
+        public static JsonPointerLiteral Parse(string pointer) => new JsonPointerLiteral(pointer);
+
+
         /// <inheritdoc />
         public override string ToString() => RawValue ?? Pointer!.ToString();
 
@@ -201,10 +217,7 @@ namespace Jaahas.Json {
         /// <param name="pointer">
         ///   The JSON Pointer.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="pointer"/> is <see langword="null"/>.
-        /// </exception>
-        public static implicit operator JsonPointerMatch(JsonPointer pointer) => new JsonPointerMatch(pointer);
+        public static implicit operator JsonPointerMatch(JsonPointer pointer) => pointer == null ? null! : new JsonPointerMatch(pointer);
 
 
         /// <summary>
@@ -213,14 +226,11 @@ namespace Jaahas.Json {
         /// <param name="pointer">
         ///   The JSON Pointer literal.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///   <paramref name="pointer"/> is <see langword="null"/>.
-        /// </exception>
         /// <exception cref="ArgumentException">
         ///   <paramref name="pointer"/> is not a valid JSON Pointer or a pattern match wildcard 
         ///   expression.
         /// </exception>
-        public static implicit operator JsonPointerMatch(string pointer) => new JsonPointerMatch(pointer);
+        public static implicit operator JsonPointerMatch(string pointer) => pointer == null ? null! : new JsonPointerMatch(pointer);
 
 
         /// <summary>


### PR DESCRIPTION
The implicit operators for creating `JsonPointerLiteral` and `JsonPointerMatch` instances will now return null if the `JsonPointer` or `string` passed to the operator is null.

The previous behaviour was to throw an `ArgumentNullException`.