### PR TITLE
Update how .NET Framework targets are identified

### DIFF
--- a/build/NetFX.targets
+++ b/build/NetFX.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <!-- .NET Framework targeting (required to allow compilation against .NET Framework in non-Windows environments) -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Uses the TargetFrameworkIdentifier MSBuild property to identify .NET Framework targets