### PR TITLE
Modify JsonPointerMatch to be a readonly struct

### DIFF
--- a/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
@@ -10,7 +10,7 @@ namespace Jaahas.Json {
     /// <see cref="JsonPointerMatch"/> describes a rule for matching JSON Pointer paths.
     /// </summary>
     [TypeConverter(typeof(JsonPointerMatchTypeConverter))]
-    public sealed class JsonPointerMatch {
+    public readonly struct JsonPointerMatch {
 
         /// <summary>
         /// The JSON Pointer for the rule, if a valid JSON Pointer was specified when creating the 
@@ -25,7 +25,7 @@ namespace Jaahas.Json {
         /// <summary>
         /// The raw value of the JSON Pointer or pattern match expression.
         /// </summary>
-        public string RawValue { get; } = default!;
+        public string? RawValue { get; }
 
         /// <summary>
         /// Specifies if <see cref="RawValue"/> contains a single-character pattern match wildcard.
@@ -88,7 +88,12 @@ namespace Jaahas.Json {
             }
 
             Pointer = pointer;
-            
+            _containsSingleLevelMqttWildcardSegment = false;
+            _containsMultiLevelMqttWildcardSegment = false;
+            _containsSingleCharacterPatternWildcard = false;
+            _containsMultiCharacterPatternWildcard = false;
+            RawValue = null;
+
             if (Pointer != null) {
                 RawValue = Pointer.ToString();
 
@@ -219,7 +224,7 @@ namespace Jaahas.Json {
         /// <param name="pointer">
         ///   The JSON Pointer.
         /// </param>
-        public static implicit operator JsonPointerMatch(JsonPointer pointer) => pointer == null ? null! : new JsonPointerMatch(pointer);
+        public static implicit operator JsonPointerMatch(JsonPointer pointer) => new JsonPointerMatch(pointer ?? JsonPointer.Empty);
 
 
         /// <summary>
@@ -232,7 +237,7 @@ namespace Jaahas.Json {
         ///   <paramref name="pointer"/> is not a valid JSON Pointer or a pattern match wildcard 
         ///   expression.
         /// </exception>
-        public static implicit operator JsonPointerMatch(string pointer) => pointer == null ? null! : new JsonPointerMatch(pointer);
+        public static implicit operator JsonPointerMatch(string pointer) => new JsonPointerMatch(pointer);
 
 
         /// <summary>

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
@@ -152,7 +152,7 @@ namespace Jaahas.Json {
             var predicates = new List<JsonPointerMatchDelegate>();
 
             foreach (var matchRule in matchRules) {
-                if (matchRule == null) {
+                if (matchRule.Pointer == null || string.IsNullOrWhiteSpace(matchRule.RawValue)) {
                     continue;
                 }
 

--- a/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
@@ -41,6 +41,35 @@ namespace Jaahas.Json.Tests {
 
 
         [TestMethod]
+        public void ShouldNotBindNullValue() {
+            var builder = new ConfigurationBuilder();
+
+            var config = builder.Build();
+
+            var options = new JsonPointerMatchOptions();
+            config.Bind("JsonPointerMatch", options);
+
+            Assert.IsNull(options.Match);
+        }
+
+
+        [TestMethod]
+        public void ShouldNotBindEmptyValue() {
+            var builder = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> {
+                    ["JsonPointerMatch:Match"] = ""
+                });
+
+            var config = builder.Build();
+
+            var options = new JsonPointerMatchOptions();
+            config.Bind("JsonPointerMatch", options);
+
+            Assert.IsNull(options.Match);
+        }
+
+
+        [TestMethod]
         public void ShouldBindValidJsonPointerLiteralMatch() {
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> {
@@ -54,7 +83,7 @@ namespace Jaahas.Json.Tests {
 
             Assert.IsNotNull(options.Match);
             Assert.AreEqual("/foo/bar", options.Match.ToString());
-            Assert.IsFalse(options.Match.IsWildcardMatchRule);
+            Assert.IsFalse(options.Match.Value.IsWildcardMatchRule);
         }
 
 
@@ -72,9 +101,9 @@ namespace Jaahas.Json.Tests {
 
             Assert.IsNotNull(options.Match);
             Assert.AreEqual("/foo/bar/+/baz/#", options.Match.ToString());
-            Assert.IsTrue(options.Match.IsWildcardMatchRule);
-            Assert.IsFalse(options.Match.IsPatternWildcardMatchRule);
-            Assert.IsTrue(options.Match.IsMqttWildcardMatchRule);
+            Assert.IsTrue(options.Match.Value.IsWildcardMatchRule);
+            Assert.IsFalse(options.Match.Value.IsPatternWildcardMatchRule);
+            Assert.IsTrue(options.Match.Value.IsMqttWildcardMatchRule);
         }
 
 
@@ -92,9 +121,9 @@ namespace Jaahas.Json.Tests {
 
             Assert.IsNotNull(options.Match);
             Assert.AreEqual("*/bar", options.Match.ToString());
-            Assert.IsTrue(options.Match.IsWildcardMatchRule);
-            Assert.IsTrue(options.Match.IsPatternWildcardMatchRule);
-            Assert.IsFalse(options.Match.IsMqttWildcardMatchRule);
+            Assert.IsTrue(options.Match.Value.IsWildcardMatchRule);
+            Assert.IsTrue(options.Match.Value.IsPatternWildcardMatchRule);
+            Assert.IsFalse(options.Match.Value.IsMqttWildcardMatchRule);
         }
 
 


### PR DESCRIPTION
This PR updates `JsonPointerMatch` to be a `readonly struct` instead of a `class`.