### PR TITLE
Fixed-length stack types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="JsonPointer.Net" Version="5.3.1" />
-    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />

--- a/README.md
+++ b/README.md
@@ -296,6 +296,11 @@ The samples emitted would be:
 It is also possible to omit array indexes from the sample keys when recursive mode is enabled; see below for more details.
 
 
+### Maximum Recursion Depth
+
+The `TimeSeriesExtractorOptions.MaxDepth` property controls the maximum depth of recursion when processing nested objects. By default, this property is set to `5`. If the maximum recursion depth is reached, the properties of the document at that level will be processed as if recursive mode was disabled.
+
+
 ### A Note on Recursive Mode Template Replacements
 
 In recursive mode, template replacements other than the built-in placeholders are resolved using all objects in the hierarchy from the root to the current object, and the matches are concatenated together with the configured path separator. Consider the following JSON:

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
-  "Major": 1,
+  "Major": 2,
   "Minor": 0,
   "Patch": 0,
   "PreRelease": ""

--- a/src/JsonTimeSeriesExtractor/ElementStack.cs
+++ b/src/JsonTimeSeriesExtractor/ElementStack.cs
@@ -1,0 +1,11 @@
+﻿namespace Jaahas.Json;
+
+/// <summary>
+/// A stack of <see cref="ElementStackEntry"/> items.
+/// </summary>
+internal sealed class ElementStack : FixedLengthStack<ElementStackEntry> {
+
+    /// <inheritdoc />
+    public ElementStack(int capacity) : base(capacity) { }
+
+}

--- a/src/JsonTimeSeriesExtractor/FixedLengthStack.cs
+++ b/src/JsonTimeSeriesExtractor/FixedLengthStack.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Jaahas.Json;
+
+/// <summary>
+/// <see cref="FixedLengthStack{T}"/> is a stack with a fixed length that cannot be resized.
+/// </summary>
+/// <typeparam name="T">
+///   The item type.
+/// </typeparam>
+/// <remarks>
+///
+/// <para>
+///   <see cref="FixedLengthStack{T}"/> uses <see cref="ArrayPool{T}"/> to rent a backing array to
+///   hold the stack items. The stack must be disposed when no longer required to allow the backing
+///   array to be returned to the pool.
+/// </para>
+/// 
+/// </remarks>
+internal abstract class FixedLengthStack<T> : IDisposable, IReadOnlyCollection<T> {
+
+    /// <summary>
+    /// Specifies whether the stack has been disposed.
+    /// </summary>
+    private bool _disposed;
+    
+    /// <summary>
+    /// The backing array.
+    /// </summary>
+    private readonly T[] _buffer;
+
+    /// <summary>
+    /// The maximum number of items that can be stored in the stack.
+    /// </summary>
+    private readonly int _capacity;
+    
+    /// <summary>
+    /// The current number of items in the stack.
+    /// </summary>
+    private int _count;
+    
+    /// <summary>
+    /// The number of items in the stack.
+    /// </summary>
+    public int Count => _count;
+    
+    
+    /// <summary>
+    /// Creates a new <see cref="FixedLengthStack{T}"/> instance.
+    /// </summary>
+    /// <param name="capacity">
+    ///   The maximum number of items that can be stored in the stack.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///   <paramref name="capacity"/> is less than or equal to zero.
+    /// </exception>
+    public FixedLengthStack(int capacity) {
+        if (capacity <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than zero.");
+        }
+        
+        _capacity = capacity;
+        _buffer = ArrayPool<T>.Shared.Rent(_capacity);
+    }
+
+    
+    /// <summary>
+    /// Pushes an item onto the stack.
+    /// </summary>
+    /// <param name="entry">
+    ///   The item to push.
+    /// </param>
+    /// <exception cref="ObjectDisposedException">
+    ///   The stack has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///   The stack is full.
+    /// </exception>
+    public void Push(T entry) {
+        if (_disposed) {
+            throw new ObjectDisposedException(GetType().FullName);
+        }
+        if (_count >= _capacity) {
+            throw new InvalidOperationException("The stack is full.");
+        }
+        
+        _buffer[_count++] = entry;
+    }
+    
+    
+    /// <summary>
+    /// Pops an item from the stack.
+    /// </summary>
+    /// <returns>
+    ///   The item popped from the stack.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">
+    ///   The stack has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///   The stack is empty.
+    /// </exception>
+    public T Pop() {
+        if (_disposed) {
+            throw new ObjectDisposedException(GetType().FullName);
+        }
+        if (_count == 0) {
+            throw new InvalidOperationException("The stack is empty.");
+        }
+        
+        return _buffer[--_count];
+    }
+    
+    
+    /// <summary>
+    /// Peeks at the item on the top of the stack without removing it.
+    /// </summary>
+    /// <returns>
+    ///   The item on the top of the stack.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">
+    ///   The stack has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///   The stack is empty.
+    /// </exception>
+    public T Peek() {
+        if (_disposed) {
+            throw new ObjectDisposedException(GetType().FullName);
+        }
+        if (_count == 0) {
+            throw new InvalidOperationException("The stack is empty.");
+        }
+        
+        return _buffer[_count - 1];
+    }
+
+
+    /// <inheritdoc />
+    public IEnumerator<T> GetEnumerator() {
+        if (_disposed) {
+            throw new ObjectDisposedException(GetType().FullName);
+        }
+
+        return new StackEnumerator(this);
+    }
+
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+    
+    
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+        
+        ArrayPool<T>.Shared.Return(_buffer, clearArray: true);
+        
+        _disposed = true;
+    }
+    
+    
+    /// <summary>
+    /// Enumerator for <see cref="FixedLengthStack{T}"/>.
+    /// </summary>
+    /// <remarks>
+    ///   Note that the enumerator enumerates from the bottom of the stack to the top rather
+    ///   than the top of the stack to the bottom.
+    /// </remarks>
+    private class StackEnumerator : IEnumerator<T> {
+
+        private readonly FixedLengthStack<T> _stack;
+        
+        private int _index;
+        
+        public StackEnumerator(FixedLengthStack<T> stack) {
+            _stack = stack;
+            _index = -1;
+        }
+
+
+        /// <inheritdoc />
+        public bool MoveNext() {
+            if (_index >= _stack._count) {
+                return false;
+            }
+            
+            _index++;
+            return true;
+        }
+
+
+        /// <inheritdoc />
+        public void Reset() {
+            _index = -1;
+        }
+
+
+        /// <inheritdoc />
+        public T Current => _index >= 0 ? _stack._buffer[_index] : default!;
+        
+
+        /// <inheritdoc />
+        object? IEnumerator.Current {
+            get => Current;
+        }
+
+
+        /// <inheritdoc />
+        public void Dispose() {
+            // No-op
+        }
+
+    }
+
+}

--- a/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
@@ -204,7 +204,7 @@ namespace Jaahas.Json {
             /// <remarks>
             ///   This field is initialized using a so-called poor man's lazy in <see cref="GetStandardValues(ITypeDescriptorContext)"/>.
             /// </remarks>
-            private static StandardValuesCollection? _standardValues;
+            private static StandardValuesCollection? s_standardValues;
 
 
             /// <inheritdoc />
@@ -265,7 +265,7 @@ namespace Jaahas.Json {
 
             /// <inheritdoc/>
             public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context) {
-                return _standardValues ??= new StandardValuesCollection(new[] { JsonPointer.Empty });
+                return s_standardValues ??= new StandardValuesCollection(new[] { JsonPointer.Empty });
             }
 
 

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorContext.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorContext.cs
@@ -62,7 +62,8 @@ namespace Jaahas.Json {
                     : options.MaxDepth
                 : 1;
             
-            ElementStack = new ElementStack(MaxDepth);
+            // We need to add 1 to the maximum depth to allow for the root element.
+            ElementStack = new ElementStack(MaxDepth + 1);
             TimestampStack = new TimestampStack(options.Recursive && options.AllowNestedTimestamps ? MaxDepth : 1);
 
             // We are using the default sample key template if:

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
@@ -57,7 +57,7 @@ namespace Jaahas.Json {
         /// </para>
         /// 
         /// <para>
-        ///   Use the <see cref="IncludeProperty"/> delegate to ignore JSON properties that are 
+        ///   Use the <see cref="CanProcessElement"/> delegate to ignore JSON properties that are 
         ///   not required or are used only for metadata purposes, and the <see cref="GetTemplateReplacement"/> 
         ///   delegate to define default replacement values for placeholders that are not found in 
         ///   the JSON object.
@@ -300,7 +300,8 @@ namespace Jaahas.Json {
         /// </para>
         /// 
         /// <para>
-        ///   A <see cref="MaxDepth"/> of less than one specifies that there is no recursion limit.
+        ///   <see cref="TimeSeriesExtractorConstants.DefaultMaxDepth"/> will be used if a <see cref="MaxDepth"/>
+        ///   of less than one is specified.
         /// </para>
         /// 
         /// </remarks>
@@ -402,7 +403,7 @@ namespace Jaahas.Json {
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
             if (string.IsNullOrWhiteSpace(Template)) {
-                yield return new ValidationResult($"The template cannot be null or white space.", new[] { nameof(Template) });
+                yield return new ValidationResult("The template cannot be null or white space.", [nameof(Template)]);
             }
         }
 

--- a/src/JsonTimeSeriesExtractor/TimeSeriesSample.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesSample.cs
@@ -41,7 +41,7 @@ namespace Jaahas.Json {
         ///   The sample value.
         /// </param>
         /// <param name="timestampSource">
-        ///   A flag describing the source of the specifed <paramref name="timestamp"/>.
+        ///   A flag describing the source of the specified <paramref name="timestamp"/>.
         /// </param>
         public TimeSeriesSample(string key, DateTimeOffset timestamp, object? value, TimestampSource timestampSource = TimestampSource.Unspecified) {
             Key = key ?? throw new ArgumentNullException(nameof(key));

--- a/src/JsonTimeSeriesExtractor/TimestampStack.cs
+++ b/src/JsonTimeSeriesExtractor/TimestampStack.cs
@@ -1,0 +1,11 @@
+﻿namespace Jaahas.Json;
+
+/// <summary>
+/// A stack of <see cref="ParsedTimestamp"/> items.
+/// </summary>
+internal sealed class TimestampStack : FixedLengthStack<ParsedTimestamp> {
+
+    /// <inheritdoc />
+    public TimestampStack(int capacity) : base(capacity) { }
+
+}

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net481</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jaahas.Json.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
## ⚠️ Breaking Change

This PR adds custom fixed-length stack types to hold hierarchy and timestamp data when extracting time series. The custom types use `ArrayPool<T>` under the hood to rent a buffer of an appropriate size to hold the stack items. This allows the extractor to reduce allocations when processing batches of JSON payloads.

The move to fixed-length stacks means that we no longer allow unlimited recursion when setting `TimeSeriesExtractorOptions.MaxDepth` to less than one; instead, specifying a value less than one now results in the default maximum recursion depth of 5 being used.