### PR TITLE
Refactor sample extractor and wildcard matcher for maintainability and performance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,6 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MSTest" Version="3.9.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.7" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MSTest" Version="3.9.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.7" />
   </ItemGroup>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 2,
+  "Major": 3,
   "Minor": 0,
-  "Patch": 1,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
+++ b/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <RootNamespace>Jaahas.Json</RootNamespace>
     <AssemblyName>Jaahas.Json.TimeSeriesExtractor</AssemblyName>
     <Description>A library for parsing time series data samples from JSON documents using System.Text.Json</Description>
@@ -14,6 +16,13 @@
     <PackageReference Include="JsonPointer.Net" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -28,14 +37,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
+  
   <ItemGroup>
     <None Include="docs\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
+++ b/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
@@ -15,13 +15,6 @@
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="JsonPointer.Net" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="PolySharp">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
   
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
@@ -97,11 +97,11 @@ namespace Jaahas.Json {
             JsonPointerMatchDelegate? excludePredicate = null;
 
             if (options.PointersToInclude != null) {
-                includePredicate = CreateJsonPointerMatchDelegate(options.PointersToInclude, options.AllowWildcardExpressions, options.UseCompiledRegularExpressions);
+                includePredicate = CreateJsonPointerMatchDelegateCore(options.PointersToInclude, options.AllowWildcardExpressions, options.UseCompiledRegularExpressions);
             }
 
             if (options.PointersToExclude != null) {
-                excludePredicate = CreateJsonPointerMatchDelegate(options.PointersToExclude, options.AllowWildcardExpressions, options.UseCompiledRegularExpressions);
+                excludePredicate = CreateJsonPointerMatchDelegateCore(options.PointersToExclude, options.AllowWildcardExpressions, options.UseCompiledRegularExpressions);
             }
 
             if (includePredicate == null && excludePredicate == null) {
@@ -136,7 +136,7 @@ namespace Jaahas.Json {
         ///   A predicate that returns <see langword="true"/> if the specified JSON pointer matches 
         ///   any of the <paramref name="matchRules"/>.
         /// </returns>
-        private static JsonPointerMatchDelegate CreateJsonPointerMatchDelegate(IEnumerable<JsonPointerMatch> matchRules, bool allowWildcards, bool useCompiledRegularExpressions) {
+        private static JsonPointerMatchDelegate CreateJsonPointerMatchDelegateCore(IEnumerable<JsonPointerMatch> matchRules, bool allowWildcards, bool useCompiledRegularExpressions) {
             // Optimised predicate construction: process each rule only once and avoid redundant predicates.
             var matchRuleArray = matchRules as JsonPointerMatch[] ?? matchRules.ToArray();
             var nonWildcardPointers = new List<JsonPointer>();

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
@@ -222,14 +222,22 @@ namespace Jaahas.Json {
                     var elementPointerIsLongerThanMatchPointer = pointer.Count > matchSegments.Length;
                     // The pointer has more segments than the match pattern; definitely no match unless the last match segment is a multi-level wildcard.
                     if (elementPointerIsLongerThanMatchPointer) {
+#if NETCOREAPP
                         if (!matchSegments[^1].IsMultiLevelWildcard) {
+#else
+                        if (!matchSegments[matchSegments.Length - 1].IsMultiLevelWildcard) {    
+#endif
                             return false;
                         }
                     }
                     // Only ever need to test the final segment of the element pointer, as previous segments were tested in previous iterations.
                     var pointerSegmentIndex = pointer.Count - 1;
                     var matchSegment = pointerSegmentIndex >= matchSegments.Length
+#if NETCOREAPP
                         ? matchSegments[^1]
+#else
+                        ? matchSegments[matchSegments.Length - 1]                        
+#endif
                         : matchSegments[pointerSegmentIndex];
                     
                     // Single-level wildcard: match the current segment unless the element pointer has more segments than the match pointer and we have advanced beyond the end of the match pointer.
@@ -816,7 +824,11 @@ namespace Jaahas.Json {
                 if (!options.Recursive || forceLocalName) {
                     return pointer.Count == 0
                         ? string.Empty
+#if NETCOREAPP
                         : pointer[^1];
+#else
+                        : pointer[pointer.Count - 1];
+#endif
                 }
 
                 if (options.IncludeArrayIndexesInSampleKeys || !GetElementStackInHierarchyOrder().Any(x => x.IsArrayItem)) {

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
@@ -113,11 +113,7 @@ namespace Jaahas.Json {
                     return false;
                 }
 
-                if (includePredicate != null) {
-                    return includePredicate.Invoke(context, pointer, element);
-                }
-
-                return true;
+                return includePredicate == null || includePredicate.Invoke(context, pointer, element);
             };
         }
 


### PR DESCRIPTION
⚠️ Breaking Changes!

This PR refactors the sample extractor to move handling of JSON objects and arrays to their own extraction methods for readability purposes.

The private `CreateJsonPointerMatchDelegate` method has been renamed to `CreateJsonPointerMatchDelegateCore` and has been optimised to reduce allocations and to improve performance in specific scenarios, such as when a large (>8) number of static JSON pointers are specified.

The breaking change is caused by modifying the `TimeSeriesExtractor` class to be `static` instead of `sealed`. There were no instance methods on the type so it did not make sense for the class to not be `static`.