### PR TITLE
Convert unit tests from MSTest to xUnit v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This repository uses Cake Build for cross-platform build automation. Use the fol
 ### Core Development Commands
 - **Build the solution**: `./build.sh` or `./build.ps1`
 - **Run tests**: `./build.sh --target=Test` or `./build.ps1 --target=Test`
+  - Note: running tests also builds the solution.
 - **Clean and rebuild**: `./build.sh --clean` or `./build.ps1 --clean`
 - **Create NuGet packages**: `./build.sh --target=Pack` or `./build.ps1 --target=Pack`
 
@@ -49,7 +50,7 @@ This is a C# library for extracting time series data from JSON using `System.Tex
 ### Project Structure
 - **Main library**: `src/JsonTimeSeriesExtractor/` - Core extraction functionality
 - **CLI sample**: `samples/JsonTimeSeriesExtractor.Cli/` - Command-line demonstration tool
-- **Unit tests**: `test/JsonTimeSeriesExtractor.Tests/` - MSTest-based test suite
+- **Unit tests**: `test/JsonTimeSeriesExtractor.Tests/` - xUnit v3-based test suite
 - **Benchmarks**: `test/JsonTimeSeriesExtractor.Benchmarks/` - Performance testing
 
 ## Development Guidelines
@@ -66,10 +67,10 @@ This is a C# library for extracting time series data from JSON using `System.Tex
 - Do not include version numbers in `<PackageReference>` elements
 
 ### Testing Approach
-- Uses MSTest framework
+- Uses xUnit v3 framework
 - Tests should fail initially, then be made to pass
-- Test classes must include `TestContext` property
-- File system tests should use temporary directories created in `[ClassInitialize]`
+- Test projects must be executable (`<OutputType>Exe</OutputType>`)
+- File system tests should use temporary directories created in class constructors or `IClassFixture<T>`
 - Prefer adding tests to existing test projects
 
 ### Git Workflow

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,8 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="MSTest" Version="3.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,15 +7,18 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="JsonPointer.Net" Version="5.3.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.7" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="JsonPointer.Net" Version="5.3.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 3,
   "Minor": 0,
-  "Patch": 2,
+  "Patch": 3,
   "PreRelease": ""
 }

--- a/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/ConfigurationBinderTests.cs
@@ -2,14 +2,13 @@
 using System.Collections.Generic;
 
 using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Jaahas.Json.Tests {
 
-    [TestClass]
     public class ConfigurationBinderTests {
 
-        [TestMethod]
+        [Fact]
         public void ShouldBindValidJsonPointer() {
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> {
@@ -21,12 +20,12 @@ namespace Jaahas.Json.Tests {
             var options = new TimeSeriesExtractorOptions();
             config.Bind("TimeSeriesExtractor", options);
 
-            Assert.IsNotNull(options.StartAt);
-            Assert.AreEqual("/foo/bar", options.StartAt.ToString());
+            Assert.NotNull(options.StartAt);
+            Assert.Equal("/foo/bar", options.StartAt.ToString());
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldNotBindInvalidJsonPointer() {
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> {
@@ -36,11 +35,11 @@ namespace Jaahas.Json.Tests {
             var config = builder.Build();
 
             var options = new TimeSeriesExtractorOptions();
-            Assert.ThrowsException<InvalidOperationException>(() => config.Bind("TimeSeriesExtractor", options));
+            Assert.Throws<InvalidOperationException>(() => config.Bind("TimeSeriesExtractor", options));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldNotBindNullValue() {
             var builder = new ConfigurationBuilder();
 
@@ -49,11 +48,11 @@ namespace Jaahas.Json.Tests {
             var options = new JsonPointerMatchOptions();
             config.Bind("JsonPointerMatch", options);
 
-            Assert.IsNull(options.Match);
+            Assert.Null(options.Match);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldNotBindEmptyValue() {
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> {
@@ -65,11 +64,11 @@ namespace Jaahas.Json.Tests {
             var options = new JsonPointerMatchOptions();
             config.Bind("JsonPointerMatch", options);
 
-            Assert.IsNull(options.Match);
+            Assert.Null(options.Match);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldBindValidJsonPointerLiteralMatch() {
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> {
@@ -81,13 +80,13 @@ namespace Jaahas.Json.Tests {
             var options = new JsonPointerMatchOptions();
             config.Bind("JsonPointerMatch", options);
 
-            Assert.IsNotNull(options.Match);
-            Assert.AreEqual("/foo/bar", options.Match.ToString());
-            Assert.IsFalse(options.Match.Value.IsWildcardMatchRule);
+            Assert.NotNull(options.Match);
+            Assert.Equal("/foo/bar", options.Match.ToString());
+            Assert.False(options.Match.Value.IsWildcardMatchRule);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldBindValidJsonPointerMqttMatch() {
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> {
@@ -99,15 +98,15 @@ namespace Jaahas.Json.Tests {
             var options = new JsonPointerMatchOptions();
             config.Bind("JsonPointerMatch", options);
 
-            Assert.IsNotNull(options.Match);
-            Assert.AreEqual("/foo/bar/+/baz/#", options.Match.ToString());
-            Assert.IsTrue(options.Match.Value.IsWildcardMatchRule);
-            Assert.IsFalse(options.Match.Value.IsPatternWildcardMatchRule);
-            Assert.IsTrue(options.Match.Value.IsMqttWildcardMatchRule);
+            Assert.NotNull(options.Match);
+            Assert.Equal("/foo/bar/+/baz/#", options.Match.ToString());
+            Assert.True(options.Match.Value.IsWildcardMatchRule);
+            Assert.False(options.Match.Value.IsPatternWildcardMatchRule);
+            Assert.True(options.Match.Value.IsMqttWildcardMatchRule);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldBindValidJsonPointerPatternMatch() {
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?> {
@@ -119,11 +118,11 @@ namespace Jaahas.Json.Tests {
             var options = new JsonPointerMatchOptions();
             config.Bind("JsonPointerMatch", options);
 
-            Assert.IsNotNull(options.Match);
-            Assert.AreEqual("*/bar", options.Match.ToString());
-            Assert.IsTrue(options.Match.Value.IsWildcardMatchRule);
-            Assert.IsTrue(options.Match.Value.IsPatternWildcardMatchRule);
-            Assert.IsFalse(options.Match.Value.IsMqttWildcardMatchRule);
+            Assert.NotNull(options.Match);
+            Assert.Equal("*/bar", options.Match.ToString());
+            Assert.True(options.Match.Value.IsWildcardMatchRule);
+            Assert.True(options.Match.Value.IsPatternWildcardMatchRule);
+            Assert.False(options.Match.Value.IsMqttWildcardMatchRule);
         }
 
 

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
@@ -4,12 +4,17 @@
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jaahas.Json.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="MSTest" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
@@ -95,14 +95,14 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{MacAddress}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
             }).ToArray();
 
             Assert.Equal(13, samples.Length);
             Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
             Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress)));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase!.TestMethodName! + "/" + deviceSample.MacAddress)));
         }
 
 
@@ -129,7 +129,7 @@ namespace Jaahas.Json.Tests {
 
             var guid = Guid.NewGuid();
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{Uuid}/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{MacAddress}/{Uuid}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 GetTemplateReplacement = text => { 
                     switch (text.ToUpperInvariant()) {
@@ -144,7 +144,7 @@ namespace Jaahas.Json.Tests {
             Assert.Equal(13, samples.Length);
             Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
             Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress + "/" + guid)));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase!.TestMethodName! + "/" + deviceSample.MacAddress + "/" + guid)));
         }
 
 
@@ -166,12 +166,12 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Recursive = true,
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
-                    PointersToInclude = new JsonPointerMatch[] { "/A/B/C/Value" },
+                    PointersToInclude = ["/A/B/C/Value"],
                 }),
                 Template = "{$prop-path}/{Name}"
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             Assert.Equal("A/B/C/Instrument-1", samples[0].Key);
             Assert.Equal(data.A.B.C.Value, samples[0].Value);
             Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
@@ -198,13 +198,13 @@ namespace Jaahas.Json.Tests {
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
                 Recursive = true,
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() {
-                    PointersToInclude = new JsonPointerMatch[] { "/A/B/C/0/Value" },
+                    PointersToInclude = ["/A/B/C/0/Value"],
                 }),
                 Template = "{$prop-path}/{Name}",
                 IncludeArrayIndexesInSampleKeys = false
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             Assert.Equal("A/B/C/Instrument-1", samples[0].Key);
             Assert.Equal(data.A.B.C[0].Value, samples[0].Value);
             Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
@@ -233,20 +233,20 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{DataFormat}/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{MacAddress}/{DataFormat}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
-                    PointersToExclude = new JsonPointerMatch[] {
+                    PointersToExclude = [
                         $"/{nameof(deviceSample.DataFormat)}",
                         $"/{nameof(deviceSample.MacAddress)}"
-                    }
+                    ]
                 })
             }).ToArray();
 
             Assert.Equal(11, samples.Length);
             Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
             Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase!.TestMethodName! + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
         }
 
 
@@ -272,21 +272,21 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{DataFormat}/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{MacAddress}/{DataFormat}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() {
-                    PointersToInclude = new JsonPointerMatch[] {
+                    PointersToInclude = [
                         $"/{nameof(deviceSample.Temperature)}",
                         $"/{nameof(deviceSample.Humidity)}",
                         $"/{nameof(deviceSample.Pressure)}"
-                    }
+                    ]
                 })
             }).ToArray();
 
             Assert.Equal(3, samples.Length);
             Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
             Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase!.TestMethodName! + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
         }
 
 
@@ -320,9 +320,9 @@ namespace Jaahas.Json.Tests {
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
                     AllowWildcardExpressions = true,
-                    PointersToInclude = new JsonPointerMatch[] {
-                        $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/#",
-                    }
+                    PointersToInclude = [
+                        $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/#"
+                    ]
                 })
             }).ToArray();
 
@@ -363,13 +363,13 @@ namespace Jaahas.Json.Tests {
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
                     AllowWildcardExpressions = true,
-                    PointersToInclude = new JsonPointerMatch[] {
-                        $"/+/+/X",
-                    }
+                    PointersToInclude = [
+                        $"/+/+/X"
+                    ]
                 })
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             var sample = samples[0];
 
             Assert.Equal(deviceSample.Data.Timestamp.UtcDateTime, sample.Timestamp.UtcDateTime);
@@ -408,13 +408,13 @@ namespace Jaahas.Json.Tests {
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
                     AllowWildcardExpressions = true,
-                    PointersToInclude = new JsonPointerMatch[] {
-                        "*/X",
-                    }
+                    PointersToInclude = [
+                        "*/X"
+                    ]
                 })
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             var sample = samples[0];
 
             Assert.Equal(deviceSample.Data.Timestamp.UtcDateTime, sample.Timestamp.UtcDateTime);
@@ -453,9 +453,9 @@ namespace Jaahas.Json.Tests {
                 TimestampProperty = JsonPointer.Parse($"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Timestamp)}"),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
                     AllowWildcardExpressions = true,
-                    PointersToInclude = new JsonPointerMatch[] {
-                        $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/?",
-                    }
+                    PointersToInclude = [
+                        $"/{nameof(deviceSample.Data)}/{nameof(deviceSample.Data.Acceleration)}/?"
+                    ]
                 })
             }).ToArray();
 
@@ -478,12 +478,12 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSamples);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/sample/{$prop}"
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/sample/{$prop}"
             }).ToArray();
 
             Assert.Equal(deviceSamples.Length, samples.Length);
             Assert.True(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
-            Assert.True(samples.All(x => string.Equals(x.Key, TestContext.Current.TestCase.TestMethodName + "/sample/Value")));
+            Assert.True(samples.All(x => string.Equals(x.Key, TestContext.Current.TestCase!.TestMethodName! + "/sample/Value")));
 
             for (var i = 0; i < deviceSamples.Length; i++) {
                 Assert.Equal(deviceSamples[i].Value, (double) samples[i].Value!);
@@ -530,7 +530,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 Recursive = true
             }).ToArray();
@@ -560,7 +560,7 @@ namespace Jaahas.Json.Tests {
                 CanProcessElement = (_, prop, _) => !prop.Last().Equals("location")
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             Assert.Equal("System A/Subsystem 1/measurements/temperature", samples[0].Key);
             Assert.True(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
         }
@@ -585,7 +585,7 @@ namespace Jaahas.Json.Tests {
                 CanProcessElement = (_, prop, _) => !prop.Last().Equals("location")
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             Assert.Equal("System A/Subsystem 1/temperature", samples[0].Key);
             Assert.True(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
         }
@@ -637,11 +637,11 @@ namespace Jaahas.Json.Tests {
                 MaxDepth = 3,
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
                     AllowWildcardExpressions = true,
-                    PointersToInclude = new JsonPointerMatch[] { "/+/+/value" }
+                    PointersToInclude = ["/+/+/value"]
                 })
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             Assert.Equal("parent/child/value", samples[0].Key);
             Assert.Equal(testObject.parent.child.value, samples[0].Value);
             Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
@@ -659,11 +659,11 @@ namespace Jaahas.Json.Tests {
             var fallbackTimestamp = DateTimeOffset.Parse("1999-12-31");
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{$prop}",
                 GetDefaultTimestamp = () => fallbackTimestamp
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
+            Assert.Single(samples);
             Assert.Equal(fallbackTimestamp, samples[0].Timestamp);
             Assert.Equal(TimestampSource.FallbackProvider, samples[0].TimestampSource);
         }
@@ -675,15 +675,15 @@ namespace Jaahas.Json.Tests {
                 value = 99
             };
 
-            string json = JsonSerializer.Serialize(testObject);
+            var json = JsonSerializer.Serialize(testObject);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() { 
-                Template = TestContext.Current.TestCase.TestMethodName + "/{deviceId}/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{deviceId}/{$prop}",
                 AllowUnresolvedTemplateReplacements = true
             }).ToArray();
 
-            Assert.Equal(1, samples.Length);
-            Assert.Equal(TestContext.Current.TestCase.TestMethodName + "/{deviceId}/value", samples[0].Key);
+            Assert.Single(samples);
+            Assert.Equal(TestContext.Current.TestCase!.TestMethodName! + "/{deviceId}/value", samples[0].Key);
             Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
         }
 
@@ -694,20 +694,20 @@ namespace Jaahas.Json.Tests {
                 value = 99
             };
 
-            string json = JsonSerializer.Serialize(testObject);
+            var json = JsonSerializer.Serialize(testObject);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.Current.TestCase.TestMethodName + "/{deviceId}/{$prop}",
+                Template = TestContext.Current.TestCase!.TestMethodName! + "/{deviceId}/{$prop}",
                 AllowUnresolvedTemplateReplacements = false
             }).ToArray();
 
-            Assert.Equal(0, samples.Length);
+            Assert.Empty(samples);
         }
 
 
         [Fact]
         public void ShouldAllowNumericalTimestamp() {
-            long ms = 1646312969367;
+            var ms = 1646312969367L;
 
             var deviceSample = new {
                 Timestamp = ms,
@@ -778,7 +778,7 @@ namespace Jaahas.Json.Tests {
 
         [Fact]
         public void ShouldAllowCustomStartPosition() {
-            long ms = 1646312969367;
+            var ms = 1646312969367L;
 
             var deviceSample = new {
                 data = new {

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
@@ -4,17 +4,14 @@ using System.Text.Json;
 
 using Json.Pointer;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Jaahas.Json.Tests {
 
-    [TestClass]
     public class JsonTimeSeriesExtractorTests {
 
-        public TestContext TestContext { get; set; } = default!;
 
-
-        [TestMethod]
+        [Fact]
         public void ShouldExtractSamplesFromJsonForAllNonTimestampFields() {
             var deviceSample = new {
                 Timestamp = DateTimeOffset.Parse("2021-05-28T17:41:09.7031076+03:00"),
@@ -39,13 +36,13 @@ namespace Jaahas.Json.Tests {
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp))
             }).ToArray();
 
-            Assert.AreEqual(13, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.Equal(13, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldUseDefaultKeyTemplate() {
             var deviceSample = new {
                 Timestamp = DateTimeOffset.Parse("2021-05-28T17:41:09.7031076+03:00"),
@@ -70,13 +67,13 @@ namespace Jaahas.Json.Tests {
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp))
             }).ToArray();
 
-            Assert.AreEqual(13, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.Equal(13, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldUseCustomKeyTemplate() {
             var deviceSample = new {
                 Timestamp = DateTimeOffset.Parse("2021-05-28T17:41:09.7031076+03:00"),
@@ -98,18 +95,18 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/{MacAddress}/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
             }).ToArray();
 
-            Assert.AreEqual(13, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.IsTrue(samples.All(x => x.Key.StartsWith(TestContext.TestName + "/" + deviceSample.MacAddress)));
+            Assert.Equal(13, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress)));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldUseCustomKeyTemplateWithDefaultReplacements() {
             var deviceSample = new {
                 Timestamp = DateTimeOffset.Parse("2021-05-28T17:41:09.7031076+03:00"),
@@ -132,7 +129,7 @@ namespace Jaahas.Json.Tests {
 
             var guid = Guid.NewGuid();
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/{MacAddress}/{Uuid}/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{Uuid}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 GetTemplateReplacement = text => { 
                     switch (text.ToUpperInvariant()) {
@@ -144,14 +141,14 @@ namespace Jaahas.Json.Tests {
                 }
             }).ToArray();
 
-            Assert.AreEqual(13, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.IsTrue(samples.All(x => x.Key.StartsWith(TestContext.TestName + "/" + deviceSample.MacAddress + "/" + guid)));
+            Assert.Equal(13, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress + "/" + guid)));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldUsePropertyPathInCustomTemplate() {
             var data = new { 
                 A = new { 
@@ -174,14 +171,14 @@ namespace Jaahas.Json.Tests {
                 Template = "{$prop-path}/{Name}"
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
-            Assert.AreEqual("A/B/C/Instrument-1", samples[0].Key);
-            Assert.AreEqual(data.A.B.C.Value, samples[0].Value);
-            Assert.AreEqual(TimestampSource.CurrentTime, samples[0].TimestampSource);
+            Assert.Equal(1, samples.Length);
+            Assert.Equal("A/B/C/Instrument-1", samples[0].Key);
+            Assert.Equal(data.A.B.C.Value, samples[0].Value);
+            Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldUsePropertyPathWithoutArrayIndexesInCustomTemplate() {
             var data = new {
                 A = new {
@@ -207,14 +204,14 @@ namespace Jaahas.Json.Tests {
                 IncludeArrayIndexesInSampleKeys = false
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
-            Assert.AreEqual("A/B/C/Instrument-1", samples[0].Key);
-            Assert.AreEqual(data.A.B.C[0].Value, samples[0].Value);
-            Assert.AreEqual(TimestampSource.CurrentTime, samples[0].TimestampSource);
+            Assert.Equal(1, samples.Length);
+            Assert.Equal("A/B/C/Instrument-1", samples[0].Key);
+            Assert.Equal(data.A.B.C[0].Value, samples[0].Value);
+            Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldExcludeSpecifiedProperties() {
             var deviceSample = new {
                 Timestamp = DateTimeOffset.Parse("2021-05-28T17:41:09.7031076+03:00"),
@@ -236,7 +233,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/{MacAddress}/{DataFormat}/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{DataFormat}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() { 
                     PointersToExclude = new JsonPointerMatch[] {
@@ -246,14 +243,14 @@ namespace Jaahas.Json.Tests {
                 })
             }).ToArray();
 
-            Assert.AreEqual(11, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.IsTrue(samples.All(x => x.Key.StartsWith(TestContext.TestName + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
+            Assert.Equal(11, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludeSpecifiedProperties() {
             var deviceSample = new {
                 Timestamp = DateTimeOffset.Parse("2021-05-28T17:41:09.7031076+03:00"),
@@ -275,7 +272,7 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/{MacAddress}/{DataFormat}/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{MacAddress}/{DataFormat}/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 CanProcessElement = TimeSeriesExtractor.CreateJsonPointerMatchDelegate(new JsonPointerMatchDelegateOptions() {
                     PointersToInclude = new JsonPointerMatch[] {
@@ -286,14 +283,14 @@ namespace Jaahas.Json.Tests {
                 })
             }).ToArray();
 
-            Assert.AreEqual(3, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.IsTrue(samples.All(x => x.Key.StartsWith(TestContext.TestName + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
+            Assert.Equal(3, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Key.StartsWith(TestContext.Current.TestCase.TestMethodName + "/" + deviceSample.MacAddress + "/" + deviceSample.DataFormat)));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludePropertiesUsingMqttMultiLevelMatch() {
             var deviceSample = new { 
                 Data = new {
@@ -329,14 +326,14 @@ namespace Jaahas.Json.Tests {
                 })
             }).ToArray();
 
-            Assert.AreEqual(3, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Data.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.IsTrue(samples.All(x => x.Key.StartsWith("Data/Acceleration/")));
+            Assert.Equal(3, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Data.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Key.StartsWith("Data/Acceleration/")));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludePropertiesUsingMqttSingleLevelMatch() {
             var deviceSample = new {
                 Data = new {
@@ -372,16 +369,16 @@ namespace Jaahas.Json.Tests {
                 })
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
+            Assert.Equal(1, samples.Length);
             var sample = samples[0];
 
-            Assert.AreEqual(deviceSample.Data.Timestamp.UtcDateTime, sample.Timestamp.UtcDateTime);
-            Assert.AreEqual(TimestampSource.Document, sample.TimestampSource);
-            Assert.AreEqual("Data/Acceleration/X", sample.Key);
+            Assert.Equal(deviceSample.Data.Timestamp.UtcDateTime, sample.Timestamp.UtcDateTime);
+            Assert.Equal(TimestampSource.Document, sample.TimestampSource);
+            Assert.Equal("Data/Acceleration/X", sample.Key);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludePropertiesUsingMultiCharacterPatternMatch() {
             var deviceSample = new {
                 Data = new {
@@ -417,16 +414,16 @@ namespace Jaahas.Json.Tests {
                 })
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
+            Assert.Equal(1, samples.Length);
             var sample = samples[0];
 
-            Assert.AreEqual(deviceSample.Data.Timestamp.UtcDateTime, sample.Timestamp.UtcDateTime);
-            Assert.AreEqual(TimestampSource.Document, sample.TimestampSource);
-            Assert.AreEqual("Data/Acceleration/X", sample.Key);
+            Assert.Equal(deviceSample.Data.Timestamp.UtcDateTime, sample.Timestamp.UtcDateTime);
+            Assert.Equal(TimestampSource.Document, sample.TimestampSource);
+            Assert.Equal("Data/Acceleration/X", sample.Key);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludePropertiesUsingSingleCharacterPatternMatch() {
             var deviceSample = new {
                 Data = new {
@@ -462,14 +459,14 @@ namespace Jaahas.Json.Tests {
                 })
             }).ToArray();
 
-            Assert.AreEqual(3, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Data.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.IsTrue(samples.All(x => x.Key.StartsWith("Data/Acceleration/")));
+            Assert.Equal(3, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Data.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Key.StartsWith("Data/Acceleration/")));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldParseTopLevelArray() {
             var deviceSamples = new[] {
                 new { Value = 55.5 },
@@ -481,20 +478,20 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSamples);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/sample/{$prop}"
+                Template = TestContext.Current.TestCase.TestMethodName + "/sample/{$prop}"
             }).ToArray();
 
-            Assert.AreEqual(deviceSamples.Length, samples.Length);
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
-            Assert.IsTrue(samples.All(x => string.Equals(x.Key, TestContext.TestName + "/sample/Value")));
+            Assert.Equal(deviceSamples.Length, samples.Length);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
+            Assert.True(samples.All(x => string.Equals(x.Key, TestContext.Current.TestCase.TestMethodName + "/sample/Value")));
 
             for (var i = 0; i < deviceSamples.Length; i++) {
-                Assert.AreEqual(deviceSamples[i].Value, (double) samples[i].Value!, $"Samples at index {i} are different.");
+                Assert.Equal(deviceSamples[i].Value, (double) samples[i].Value!);
             }
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldRecursivelyParseObject() {
             var deviceSample = new {
                 Timestamp = DateTimeOffset.Parse("2021-05-28T17:41:09.7031076+03:00"),
@@ -533,18 +530,18 @@ namespace Jaahas.Json.Tests {
             var json = JsonSerializer.Serialize(deviceSample);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{$prop}",
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp)),
                 Recursive = true
             }).ToArray();
 
-            Assert.AreEqual(16, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.Equal(16, samples.Length);
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(deviceSample.Timestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldApplyRecursiveTemplateReplacements() {
             var testObject = new { 
                 location = "System A",
@@ -563,13 +560,13 @@ namespace Jaahas.Json.Tests {
                 CanProcessElement = (_, prop, _) => !prop.Last().Equals("location")
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
-            Assert.AreEqual("System A/Subsystem 1/measurements/temperature", samples[0].Key);
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
+            Assert.Equal(1, samples.Length);
+            Assert.Equal("System A/Subsystem 1/measurements/temperature", samples[0].Key);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldApplyRecursiveTemplateReplacementsWithLocalPropertyName() {
             var testObject = new {
                 location = "System A",
@@ -588,13 +585,13 @@ namespace Jaahas.Json.Tests {
                 CanProcessElement = (_, prop, _) => !prop.Last().Equals("location")
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
-            Assert.AreEqual("System A/Subsystem 1/temperature", samples[0].Key);
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
+            Assert.Equal(1, samples.Length);
+            Assert.Equal("System A/Subsystem 1/temperature", samples[0].Key);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldObeyRecursionDepthLimit() {
             var testObject = new {
                 location = "System A",
@@ -611,19 +608,19 @@ namespace Jaahas.Json.Tests {
                 MaxDepth = 1
             }).ToArray();
 
-            Assert.AreEqual(2, samples.Length);
+            Assert.Equal(2, samples.Length);
 
-            Assert.AreEqual("location", samples[0].Key);
-            Assert.AreEqual(testObject.location, samples[0].Value);
+            Assert.Equal("location", samples[0].Key);
+            Assert.Equal(testObject.location, samples[0].Value);
             
-            Assert.AreEqual("measurements", samples[1].Key);
-            Assert.AreEqual(@"{""location"":""Subsystem 1"",""temperature"":14}", samples[1].Value);
+            Assert.Equal("measurements", samples[1].Key);
+            Assert.Equal(@"{""location"":""Subsystem 1"",""temperature"":14}", samples[1].Value);
 
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.CurrentTime));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldObeyRecursionDepthLimitWhenUsingAnInclusionDelegate() {
             var testObject = new {
                 parent = new {
@@ -644,14 +641,14 @@ namespace Jaahas.Json.Tests {
                 })
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
-            Assert.AreEqual("parent/child/value", samples[0].Key);
-            Assert.AreEqual(testObject.parent.child.value, samples[0].Value);
-            Assert.AreEqual(TimestampSource.CurrentTime, samples[0].TimestampSource);
+            Assert.Equal(1, samples.Length);
+            Assert.Equal("parent/child/value", samples[0].Key);
+            Assert.Equal(testObject.parent.child.value, samples[0].Value);
+            Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldUseFallbackTimestamp() {
             var testObject = new { 
                 value = 99
@@ -662,17 +659,17 @@ namespace Jaahas.Json.Tests {
             var fallbackTimestamp = DateTimeOffset.Parse("1999-12-31");
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{$prop}",
                 GetDefaultTimestamp = () => fallbackTimestamp
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
-            Assert.AreEqual(fallbackTimestamp, samples[0].Timestamp);
-            Assert.AreEqual(TimestampSource.FallbackProvider, samples[0].TimestampSource);
+            Assert.Equal(1, samples.Length);
+            Assert.Equal(fallbackTimestamp, samples[0].Timestamp);
+            Assert.Equal(TimestampSource.FallbackProvider, samples[0].TimestampSource);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldAllowUnresolvedTemplateReplacements() {
             var testObject = new {
                 value = 99
@@ -681,17 +678,17 @@ namespace Jaahas.Json.Tests {
             string json = JsonSerializer.Serialize(testObject);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() { 
-                Template = TestContext.TestName + "/{deviceId}/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{deviceId}/{$prop}",
                 AllowUnresolvedTemplateReplacements = true
             }).ToArray();
 
-            Assert.AreEqual(1, samples.Length);
-            Assert.AreEqual(TestContext.TestName + "/{deviceId}/value", samples[0].Key);
-            Assert.AreEqual(TimestampSource.CurrentTime, samples[0].TimestampSource);
+            Assert.Equal(1, samples.Length);
+            Assert.Equal(TestContext.Current.TestCase.TestMethodName + "/{deviceId}/value", samples[0].Key);
+            Assert.Equal(TimestampSource.CurrentTime, samples[0].TimestampSource);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldNotAllowUnresolvedTemplateReplacements() {
             var testObject = new {
                 value = 99
@@ -700,15 +697,15 @@ namespace Jaahas.Json.Tests {
             string json = JsonSerializer.Serialize(testObject);
 
             var samples = TimeSeriesExtractor.GetSamples(json, new TimeSeriesExtractorOptions() {
-                Template = TestContext.TestName + "/{deviceId}/{$prop}",
+                Template = TestContext.Current.TestCase.TestMethodName + "/{deviceId}/{$prop}",
                 AllowUnresolvedTemplateReplacements = false
             }).ToArray();
 
-            Assert.AreEqual(0, samples.Length);
+            Assert.Equal(0, samples.Length);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldAllowNumericalTimestamp() {
             long ms = 1646312969367;
 
@@ -735,15 +732,15 @@ namespace Jaahas.Json.Tests {
                 TimestampProperty = JsonPointer.Parse("/" + nameof(deviceSample.Timestamp))
             }).ToArray();
 
-            Assert.AreEqual(13, samples.Length);
+            Assert.Equal(13, samples.Length);
 
             var expectedTimestamp = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMilliseconds(ms);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(expectedTimestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(expectedTimestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldAllowCustomTimestampParsing() {
             long secs = 1686559277;
 
@@ -771,15 +768,15 @@ namespace Jaahas.Json.Tests {
                 TimestampParser = element => new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(element.GetInt64())
             }).ToArray();
 
-            Assert.AreEqual(13, samples.Length);
+            Assert.Equal(13, samples.Length);
 
             var expectedTimestamp = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(secs);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(expectedTimestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(expectedTimestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldAllowCustomStartPosition() {
             long ms = 1646312969367;
 
@@ -811,16 +808,16 @@ namespace Jaahas.Json.Tests {
                 Recursive = true
             }).ToArray();
 
-            Assert.AreEqual(13, samples.Length);
-            Assert.IsTrue(samples.All(x => x.Key.StartsWith("device1/")));
+            Assert.Equal(13, samples.Length);
+            Assert.True(samples.All(x => x.Key.StartsWith("device1/")));
 
             var expectedTimestamp = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMilliseconds(ms);
-            Assert.IsTrue(samples.All(x => x.Timestamp.UtcDateTime.Equals(expectedTimestamp.UtcDateTime)));
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Timestamp.UtcDateTime.Equals(expectedTimestamp.UtcDateTime)));
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldAllowNestedTimestampsInRecursiveMode() {
             var now = DateTimeOffset.UtcNow;
 
@@ -845,16 +842,16 @@ namespace Jaahas.Json.Tests {
                 AllowNestedTimestamps = true
             }).ToArray();
 
-            Assert.AreEqual(2, samples.Length);
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.AreEqual(deviceSample.data[0].time, samples[0].Timestamp);
-            Assert.AreEqual(deviceSample.data[0].temperature, samples[0].Value);
-            Assert.AreEqual(deviceSample.data[1].time, samples[1].Timestamp);
-            Assert.AreEqual(deviceSample.data[1].temperature, samples[1].Value);
+            Assert.Equal(2, samples.Length);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.Equal(deviceSample.data[0].time, samples[0].Timestamp);
+            Assert.Equal(deviceSample.data[0].temperature, samples[0].Value);
+            Assert.Equal(deviceSample.data[1].time, samples[1].Timestamp);
+            Assert.Equal(deviceSample.data[1].temperature, samples[1].Value);
         }
         
 
-        [TestMethod]
+        [Fact]
         public void ShouldNotAllowNestedTimestampsInRecursiveMode() {
             var now = DateTimeOffset.UtcNow;
 
@@ -880,18 +877,18 @@ namespace Jaahas.Json.Tests {
             }).ToArray();
 
             // 4 samples because the nested time properties are not treated as timestamps
-            Assert.AreEqual(4, samples.Length);
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.IsTrue(samples.All(x => x.Timestamp.Equals(deviceSample.time)));
+            Assert.Equal(4, samples.Length);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.True(samples.All(x => x.Timestamp.Equals(deviceSample.time)));
 
-            Assert.AreEqual(JsonSerializer.Serialize(deviceSample.data[0].time).Trim('"'), samples[0].Value);
-            Assert.AreEqual(deviceSample.data[0].temperature, samples[1].Value);
-            Assert.AreEqual(JsonSerializer.Serialize(deviceSample.data[1].time).Trim('"'), samples[2].Value);
-            Assert.AreEqual(deviceSample.data[1].temperature, samples[3].Value);
+            Assert.Equal(JsonSerializer.Serialize(deviceSample.data[0].time).Trim('"'), samples[0].Value);
+            Assert.Equal(deviceSample.data[0].temperature, samples[1].Value);
+            Assert.Equal(JsonSerializer.Serialize(deviceSample.data[1].time).Trim('"'), samples[2].Value);
+            Assert.Equal(deviceSample.data[1].temperature, samples[3].Value);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldInheritTimestampFromAncestorLevelInRecursiveMode() {
             var now = DateTimeOffset.UtcNow;
 
@@ -916,16 +913,16 @@ namespace Jaahas.Json.Tests {
                 AllowNestedTimestamps = true
             }).ToArray();
 
-            Assert.AreEqual(2, samples.Length);
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.AreEqual(deviceSample.data.time, samples[0].Timestamp);
-            Assert.AreEqual(deviceSample.data.time, samples[1].Timestamp);
-            Assert.AreEqual(deviceSample.data.samples[0].temperature, samples[0].Value);
-            Assert.AreEqual(deviceSample.data.samples[1].temperature, samples[1].Value);
+            Assert.Equal(2, samples.Length);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.Equal(deviceSample.data.time, samples[0].Timestamp);
+            Assert.Equal(deviceSample.data.time, samples[1].Timestamp);
+            Assert.Equal(deviceSample.data.samples[0].temperature, samples[0].Value);
+            Assert.Equal(deviceSample.data.samples[1].temperature, samples[1].Value);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludeArrayIndexesInSampleKeys() {
             var now = DateTimeOffset.UtcNow;
 
@@ -950,20 +947,20 @@ namespace Jaahas.Json.Tests {
                 IncludeArrayIndexesInSampleKeys = true
             }).ToArray(); 
 
-            Assert.AreEqual(2, samples.Length);
+            Assert.Equal(2, samples.Length);
 
-            Assert.AreEqual("data/0/temperature", samples[0].Key);
-            Assert.AreEqual("data/1/temperature", samples[1].Key);
+            Assert.Equal("data/0/temperature", samples[0].Key);
+            Assert.Equal("data/1/temperature", samples[1].Key);
 
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.AreEqual(deviceSample.data[0].time, samples[0].Timestamp);
-            Assert.AreEqual(deviceSample.data[1].time, samples[1].Timestamp);
-            Assert.AreEqual(deviceSample.data[0].temperature, samples[0].Value);
-            Assert.AreEqual(deviceSample.data[1].temperature, samples[1].Value);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.Equal(deviceSample.data[0].time, samples[0].Timestamp);
+            Assert.Equal(deviceSample.data[1].time, samples[1].Timestamp);
+            Assert.Equal(deviceSample.data[0].temperature, samples[0].Value);
+            Assert.Equal(deviceSample.data[1].temperature, samples[1].Value);
         }
 
 
-        [TestMethod]
+        [Fact]
         public void ShouldNotIncludeArrayIndexesInSampleKeys() {
             var now = DateTimeOffset.UtcNow;
 
@@ -988,16 +985,16 @@ namespace Jaahas.Json.Tests {
                 IncludeArrayIndexesInSampleKeys = false
             }).ToArray();
 
-            Assert.AreEqual(2, samples.Length);
+            Assert.Equal(2, samples.Length);
 
-            Assert.AreEqual("data/temperature", samples[0].Key);
-            Assert.AreEqual("data/temperature", samples[1].Key);
+            Assert.Equal("data/temperature", samples[0].Key);
+            Assert.Equal("data/temperature", samples[1].Key);
 
-            Assert.IsTrue(samples.All(x => x.TimestampSource == TimestampSource.Document));
-            Assert.AreEqual(deviceSample.data[0].time, samples[0].Timestamp);
-            Assert.AreEqual(deviceSample.data[1].time, samples[1].Timestamp);
-            Assert.AreEqual(deviceSample.data[0].temperature, samples[0].Value);
-            Assert.AreEqual(deviceSample.data[1].temperature, samples[1].Value);
+            Assert.True(samples.All(x => x.TimestampSource == TimestampSource.Document));
+            Assert.Equal(deviceSample.data[0].time, samples[0].Timestamp);
+            Assert.Equal(deviceSample.data[1].time, samples[1].Timestamp);
+            Assert.Equal(deviceSample.data[0].temperature, samples[0].Value);
+            Assert.Equal(deviceSample.data[1].temperature, samples[1].Value);
         }
 
     }


### PR DESCRIPTION
## Summary
- Convert unit test framework from MSTest to xUnit v3
- Update package references and project configuration
- Convert all test assertions to xUnit syntax
- Fix build warnings in test project configuration
- Update documentation to reflect xUnit v3 usage
- Bump package versions and increment patch version to 3.0.3

## Test plan
- [x] All existing tests pass with xUnit v3 framework
- [x] Build succeeds without warnings
- [x] Test project is properly configured as executable
- [x] Package references are correctly updated
- [x] Documentation reflects the test framework change

🤖 Generated with [Claude Code](https://claude.ai/code)