### PR TITLE
Upgrade JsonPointer.Net + net10.0 target

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,14 +20,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(IncludeDevelopmentPackages)' == 'true' ">    
-    <!-- SourceLink NuGet Package -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <!-- .NET Framework targeting support (required to allow compilation against .NET Framework in 
        non-Windows environments). -->
   <Import Project=".\build\NetFX.targets" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,21 +4,26 @@
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
     <NoWarn>NU1507;$(NoWarn)</NoWarn>
   </PropertyGroup>
+  
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageVersion Include="JsonPointer.Net" Version="5.3.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
+    <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="JsonPointer.Net" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="xunit.v3" Version="3.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.2" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 3,
+  "Major": 4,
   "Minor": 0,
-  "Patch": 3,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/samples/JsonTimeSeriesExtractor.Cli/JsonTimeSeriesExtractor.Cli.csproj
+++ b/samples/JsonTimeSeriesExtractor.Cli/JsonTimeSeriesExtractor.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/JsonTimeSeriesExtractor/ElementStack.cs
+++ b/src/JsonTimeSeriesExtractor/ElementStack.cs
@@ -19,7 +19,7 @@ internal sealed class ElementStack : IDisposable {
     /// Specifies whether the stack has been disposed.
     /// </summary>
     private bool _disposed;
-    
+
     /// <summary>
     /// The backing array.
     /// </summary>
@@ -29,18 +29,18 @@ internal sealed class ElementStack : IDisposable {
     /// The maximum number of items that can be stored in the stack.
     /// </summary>
     private readonly int _capacity;
-    
+
     /// <summary>
     /// The current number of items in the stack.
     /// </summary>
     private int _count;
-    
+
     /// <summary>
     /// The number of items in the stack.
     /// </summary>
     public int Count => _count;
-    
-    
+
+
     /// <summary>
     /// Creates a new <see cref="ElementStack"/> instance.
     /// </summary>
@@ -54,12 +54,12 @@ internal sealed class ElementStack : IDisposable {
         if (capacity <= 0) {
             throw new ArgumentOutOfRangeException(nameof(capacity), Resources.Error_StackCapacityTooSmall);
         }
-        
+
         _capacity = capacity;
         _buffer = ArrayPool<ElementStackEntry>.Shared.Rent(_capacity);
     }
 
-    
+
     /// <summary>
     /// Pushes an item onto the stack.
     /// </summary>
@@ -79,11 +79,11 @@ internal sealed class ElementStack : IDisposable {
         if (_count >= _capacity) {
             throw new InvalidOperationException(Resources.Error_StackIsFull);
         }
-        
+
         _buffer[_count++] = entry;
     }
-    
-    
+
+
     /// <summary>
     /// Pops an item from the stack.
     /// </summary>
@@ -103,11 +103,11 @@ internal sealed class ElementStack : IDisposable {
         if (_count == 0) {
             throw new InvalidOperationException(Resources.Error_StackIsEmpty);
         }
-        
+
         return _buffer[--_count];
     }
-    
-    
+
+
     /// <summary>
     /// Peeks at the item on the top of the stack without removing it.
     /// </summary>
@@ -127,10 +127,10 @@ internal sealed class ElementStack : IDisposable {
         if (_count == 0) {
             throw new InvalidOperationException(Resources.Error_StackIsEmpty);
         }
-        
+
         return _buffer[_count - 1];
     }
-    
+
 
     /// <summary>
     /// Returns the first element that matches the specified condition.
@@ -148,17 +148,17 @@ internal sealed class ElementStack : IDisposable {
         if (_disposed) {
             throw new ObjectDisposedException(nameof(ElementStack));
         }
-        
+
         for (var i = 0; i < _count; i++) {
             if (predicate(_buffer[i])) {
                 return _buffer[i];
             }
         }
-        
+
         return default;
     }
-    
-    
+
+
     /// <summary>
     /// Gets a read-only span of the stack entries.
     /// </summary>
@@ -166,21 +166,21 @@ internal sealed class ElementStack : IDisposable {
     ///   A read-only span of the stack entries.
     /// </returns>
     public ReadOnlySpan<ElementStackEntry> AsSpan() => _buffer.AsSpan(0, _count);
-    
-    
+
+
     /// <inheritdoc />
     public void Dispose() {
         if (_disposed) {
             return;
         }
-        
+
         // Manually clear only the used portion to optimize performance while preventing memory leaks
         if (_count > 0) {
             Array.Clear(_buffer, 0, _count);
         }
-        
+
         ArrayPool<ElementStackEntry>.Shared.Return(_buffer, clearArray: false);
-        
+
         _disposed = true;
     }
 

--- a/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerLiteral.cs
@@ -16,12 +16,7 @@ namespace Jaahas.Json {
         /// <summary>
         /// The JSON Pointer.
         /// </summary>
-        private readonly JsonPointer _pointer;
-
-        /// <summary>
-        /// The JSON Pointer.
-        /// </summary>
-        public JsonPointer Pointer => _pointer ?? JsonPointer.Empty;
+        public JsonPointer Pointer { get; }
 
 
         /// <summary>
@@ -34,7 +29,7 @@ namespace Jaahas.Json {
         ///   <paramref name="pointer"/> is <see langword="null"/>.
         /// </exception>
         public JsonPointerLiteral(JsonPointer pointer) {
-            _pointer = pointer ?? throw new ArgumentNullException(nameof(pointer));
+            Pointer = pointer;
         }
 
 
@@ -55,7 +50,7 @@ namespace Jaahas.Json {
                 throw new ArgumentNullException(nameof(pointer));
             }
 
-            _pointer = JsonPointer.Parse(pointer);
+            Pointer = JsonPointer.Parse(pointer);
         }
 
 
@@ -75,9 +70,7 @@ namespace Jaahas.Json {
         /// </returns>
         public static bool TryParse(
             string? pointer,
-#if NETCOREAPP
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
-#endif
             out JsonPointerLiteral? result
         ) {
             if (pointer == null) {
@@ -124,9 +117,7 @@ namespace Jaahas.Json {
         /// <inheritdoc />
         public override bool Equals(object? obj) => obj is JsonPointerLiteral other
             ? Equals(other)
-            : obj is JsonPointer pointer
-                ? Pointer.Equals(pointer)
-                : false;
+            : obj is JsonPointer pointer && Pointer.Equals(pointer);
 
 
         /// <inheritdoc />
@@ -178,7 +169,7 @@ namespace Jaahas.Json {
         /// <param name="pointer">
         ///   The JSON Pointer.
         /// </param>
-        public static implicit operator JsonPointerLiteral(JsonPointer pointer) => pointer == null ? default : new JsonPointerLiteral(pointer);
+        public static implicit operator JsonPointerLiteral(JsonPointer pointer) => new JsonPointerLiteral(pointer);
 
 
         /// <summary>
@@ -220,18 +211,13 @@ namespace Jaahas.Json {
 
 
             /// <inheritdoc />
-            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value) {
-                if (value is string s) {
-                    return new JsonPointerLiteral(s);
-                }
-                else if (value is JsonPointer pointer) {
-                    return new JsonPointerLiteral(pointer);
-                }
-                else if (value is JsonPointerLiteral literal) {
-                    return literal;
-                }
-
-                throw GetConvertFromException(value);
+            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value) {
+                return value switch {
+                    string s => new JsonPointerLiteral(s),
+                    JsonPointer pointer => new JsonPointerLiteral(pointer),
+                    JsonPointerLiteral literal => literal,
+                    _ => throw GetConvertFromException(value)
+                };
             }
 
 
@@ -240,10 +226,10 @@ namespace Jaahas.Json {
                 if (destinationType == typeof(string)) {
                     return value?.ToString()!;
                 }
-                else if (destinationType == typeof(JsonPointer) && value is JsonPointerLiteral pointerLiteral) {
+                if (destinationType == typeof(JsonPointer) && value is JsonPointerLiteral pointerLiteral) {
                     return pointerLiteral.Pointer;
                 }
-                else if (destinationType == typeof(JsonPointerLiteral)) {
+                if (destinationType == typeof(JsonPointerLiteral)) {
                     return value;
                 }
 
@@ -274,7 +260,7 @@ namespace Jaahas.Json {
                 if (value is string s) {
                     return TryParse(s, out _);
                 }
-                return value is JsonPointerLiteral || value is JsonPointer;
+                return value is JsonPointerLiteral or JsonPointer;
             }
 
         }

--- a/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
+++ b/src/JsonTimeSeriesExtractor/JsonPointerMatch.cs
@@ -67,7 +67,7 @@ namespace Jaahas.Json {
         /// </summary>
         public bool IsMqttWildcardMatchRule => _containsSingleLevelMqttWildcardSegment || _containsMultiLevelMqttWildcardSegment;
 
-        
+
         /// <summary>
         /// Creates a new <see cref="JsonPointerMatch"/> instance.
         /// </summary>
@@ -94,24 +94,26 @@ namespace Jaahas.Json {
             _containsMultiCharacterPatternWildcard = false;
             RawValue = null;
 
-            if (Pointer != null) {
-                RawValue = Pointer.ToString();
+            if (Pointer == null) {
+                return;
+            }
 
-                for (var i = 0; i < Pointer.Count; i++) {
-                    var segment = Pointer[i];
+            RawValue = Pointer.ToString();
 
-                    if (segment.Equals(TimeSeriesExtractor.SingleLevelMqttWildcard, StringComparison.Ordinal)) {
-                        _containsSingleLevelMqttWildcardSegment = true;
-                    }
-                    else if (i == Pointer.Count - 1 && segment.Equals(TimeSeriesExtractor.MultiLevelMqttWildcard, StringComparison.Ordinal)) {
-                        _containsMultiLevelMqttWildcardSegment = true;
-                    }
-                    else if (segment.Contains(TimeSeriesExtractor.SingleCharacterWildcard)) {
-                        _containsSingleCharacterPatternWildcard = true;
-                    }
-                    else if (segment.Contains(TimeSeriesExtractor.MultiCharacterWildcard)) {
-                        _containsMultiCharacterPatternWildcard = true;
-                    }
+            for (var i = 0; i < Pointer.Value.SegmentCount; i++) {
+                var segment = Pointer.Value.GetSegment(i);
+
+                if (segment.Equals(TimeSeriesExtractor.SingleLevelMqttWildcard)) {
+                    _containsSingleLevelMqttWildcardSegment = true;
+                }
+                else if (i == Pointer.Value.SegmentCount - 1 && segment.Equals(TimeSeriesExtractor.MultiLevelMqttWildcard)) {
+                    _containsMultiLevelMqttWildcardSegment = true;
+                }
+                else if (segment.AsSpan().Contains(TimeSeriesExtractor.SingleCharacterWildcard, StringComparison.Ordinal)) {
+                    _containsSingleCharacterPatternWildcard = true;
+                }
+                else if (segment.AsSpan().Contains(TimeSeriesExtractor.MultiCharacterWildcard, StringComparison.Ordinal)) {
+                    _containsMultiCharacterPatternWildcard = true;
                 }
             }
         }
@@ -152,7 +154,7 @@ namespace Jaahas.Json {
                     _containsMultiCharacterPatternWildcard = true;
                 }
             }
-            
+
             // If we haven't been given a valid pointer, we'll throw an exception unless the
             // pointer string is a pattern expression
             if (Pointer == null && !IsPatternWildcardMatchRule) {
@@ -177,9 +179,7 @@ namespace Jaahas.Json {
         /// </returns>
         public static bool TryParse(
             string? pointer,
-#if NETCOREAPP
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
-#endif
             out JsonPointerMatch? result
         ) {
             if (pointer == null) {
@@ -215,7 +215,7 @@ namespace Jaahas.Json {
 
 
         /// <inheritdoc />
-        public override string ToString() => RawValue ?? Pointer!.ToString();
+        public override string ToString() => RawValue ?? Pointer!.Value.ToString();
 
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace Jaahas.Json {
         /// <param name="pointer">
         ///   The JSON Pointer.
         /// </param>
-        public static implicit operator JsonPointerMatch(JsonPointer pointer) => new JsonPointerMatch(pointer ?? JsonPointer.Empty);
+        public static implicit operator JsonPointerMatch(JsonPointer pointer) => new JsonPointerMatch(pointer);
 
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Jaahas.Json {
             /// <remarks>
             ///   This field is initialized using a so-called poor man's lazy in <see cref="GetStandardValues(ITypeDescriptorContext)"/>.
             /// </remarks>
-            private static StandardValuesCollection? _standardValues;
+            private static StandardValuesCollection? s_standardValues;
 
 
             /// <inheritdoc />
@@ -262,23 +262,18 @@ namespace Jaahas.Json {
 
             /// <inheritdoc />
             public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) {
-                return destinationType == typeof(string) || destinationType == typeof(JsonPointerMatch) || base.CanConvertTo(context, destinationType);
+                return destinationType == typeof(string) || destinationType == typeof(JsonPointerMatch) || destinationType != null && base.CanConvertTo(context, destinationType);
             }
 
 
             /// <inheritdoc />
-            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value) {
-                if (value is string s) {
-                    return new JsonPointerMatch(s);
-                }
-                else if (value is JsonPointer pointer) {
-                    return new JsonPointerMatch(pointer);
-                }
-                else if (value is JsonPointerMatch match) {
-                    return match;
-                }
-
-                throw GetConvertFromException(value);
+            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value) {
+                return value switch {
+                    string s => new JsonPointerMatch(s),
+                    JsonPointer pointer => new JsonPointerMatch(pointer),
+                    JsonPointerMatch match => match,
+                    _ => throw GetConvertFromException(value)
+                };
             }
 
 
@@ -287,11 +282,9 @@ namespace Jaahas.Json {
                 if (destinationType == typeof(string)) {
                     return value?.ToString()!;
                 }
-                else if (destinationType == typeof(JsonPointerMatch)) {
-                    return value;
-                }
-
-                throw GetConvertToException(value, destinationType);
+                return destinationType == typeof(JsonPointerMatch) 
+                    ? value 
+                    : throw GetConvertToException(value, destinationType);
             }
 
 
@@ -309,7 +302,7 @@ namespace Jaahas.Json {
 
             /// <inheritdoc/>
             public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context) {
-                return _standardValues ??= new StandardValuesCollection(new[] { JsonPointer.Empty });
+                return s_standardValues ??= new StandardValuesCollection(new[] { JsonPointer.Empty });
             }
 
 

--- a/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
+++ b/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Jaahas.Json</RootNamespace>

--- a/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
+++ b/src/JsonTimeSeriesExtractor/JsonTimeSeriesExtractor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Jaahas.Json</RootNamespace>

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractor.cs
@@ -18,7 +18,7 @@ namespace Jaahas.Json {
     /// <seealso cref="TimeSeriesExtractorOptions"/>
     public static partial class TimeSeriesExtractor {
 
-#if NET8_0_OR_GREATER
+#if NETCOREAPP
         /// <summary>
         /// Gets a regular expression matcher for JSON property name references in sample key templates.
         /// </summary>
@@ -145,14 +145,14 @@ namespace Jaahas.Json {
 
             foreach (var matchRule in matchRuleArray) {
                 // Ignore rules with no pointer and no raw value.
-                if (matchRule.Pointer == null && string.IsNullOrWhiteSpace(matchRule.RawValue)) {
+                if (matchRule.Pointer is null && string.IsNullOrWhiteSpace(matchRule.RawValue)) {
                     continue;
                 }
 
                 // Non-wildcard rules: collect for fast lookup.
                 if (!allowWildcards || !matchRule.IsWildcardMatchRule) {
                     // These are exact or partial pointer matches, handled together for efficiency.
-                    nonWildcardPointers.Add(matchRule.Pointer!);
+                    nonWildcardPointers.Add(matchRule.Pointer!.Value);
                     continue;
                 }
 
@@ -175,7 +175,7 @@ namespace Jaahas.Json {
                             : RegexOptions.IgnoreCase | RegexOptions.Singleline,
                         TimeSpan.FromSeconds(1));
                     wildcardPredicates.Add((context, pointer, element) => {
-                        // If the JSON element is an object or an array and we are running in recursive mode,
+                        // If the JSON element is an object or an array, and we are running in recursive mode,
                         // always return true if we have not reached our maximum recursion depth. This is required
                         // because we perform a regex match against the entire pointer string instead of doing a
                         // segment-by-segment match like we do with MQTT-style expressions so we don't want to
@@ -193,19 +193,19 @@ namespace Jaahas.Json {
                 // Multi-level wildcards are only valid in the final segment (index 0 in reversed segment list).
                 // Avoid double Reverse and ToArray allocations by using a for-loop and Span for small arrays.
                 var pointerSegments = matchRule.Pointer!;
-                var matchSegments = new (string Segment, bool IsSingleLevelWildcard, bool IsMultiLevelWildcard)[pointerSegments.Count];
-                for (var i = 0; i < pointerSegments.Count; i++) {
-                    var segment = pointerSegments[i];
+                var matchSegments = new (string Segment, bool IsSingleLevelWildcard, bool IsMultiLevelWildcard)[pointerSegments.Value.SegmentCount];
+                for (var i = 0; i < pointerSegments.Value.SegmentCount; i++) {
+                    var segment = pointerSegments.Value[i];
                     matchSegments[i] = (
-                        Segment: segment,
-                        IsSingleLevelWildcard: segment.Equals(SingleLevelMqttWildcard, StringComparison.Ordinal),
-                        IsMultiLevelWildcard: i == pointerSegments.Count - 1 && segment.Equals(MultiLevelMqttWildcard, StringComparison.Ordinal)
+                        Segment: segment.ToString(),
+                        IsSingleLevelWildcard: segment.Equals(SingleLevelMqttWildcard),
+                        IsMultiLevelWildcard: i == pointerSegments.Value.SegmentCount - 1 && segment.Equals(MultiLevelMqttWildcard)
                     );
                 }
-                
+
                 wildcardPredicates.Add((context, pointer, element) => {
                     // Special handling for when the element pointer has fewer segments than the match pointer.
-                    if (pointer.Count < matchSegments.Length) {
+                    if (pointer.SegmentCount < matchSegments.Length) {
                         // We're not running in recursive mode so definitely no match.
                         if (!context.Options.Recursive) {
                             return false;
@@ -220,40 +220,29 @@ namespace Jaahas.Json {
                             return false;
                         }
                     }
-                    var elementPointerIsLongerThanMatchPointer = pointer.Count > matchSegments.Length;
+                    var elementPointerIsLongerThanMatchPointer = pointer.SegmentCount > matchSegments.Length;
                     // The pointer has more segments than the match pattern; definitely no match unless the last match segment is a multi-level wildcard.
                     if (elementPointerIsLongerThanMatchPointer) {
-#if NETCOREAPP
                         if (!matchSegments[^1].IsMultiLevelWildcard) {
-#else
-                        if (!matchSegments[matchSegments.Length - 1].IsMultiLevelWildcard) {    
-#endif
                             return false;
                         }
                     }
                     // Only ever need to test the final segment of the element pointer, as previous segments were tested in previous iterations.
-                    var pointerSegmentIndex = pointer.Count - 1;
+                    var pointerSegmentIndex = pointer.SegmentCount - 1;
                     var matchSegment = pointerSegmentIndex >= matchSegments.Length
-#if NETCOREAPP
                         ? matchSegments[^1]
-#else
-                        ? matchSegments[matchSegments.Length - 1]                        
-#endif
                         : matchSegments[pointerSegmentIndex];
-                    
-                    // Single-level wildcard: match the current segment unless the element pointer has more segments than the match pointer and we have advanced beyond the end of the match pointer.
+
+                    // Single-level wildcard: match the current segment unless the element pointer has more segments than the match pointer, and we have advanced beyond the end of the match pointer.
                     if (matchSegment.IsSingleLevelWildcard) {
-                        if (elementPointerIsLongerThanMatchPointer && pointerSegmentIndex >= matchSegments.Length) {
-                            return false;
-                        }
-                        return true;
+                        return !elementPointerIsLongerThanMatchPointer || pointerSegmentIndex < matchSegments.Length;
                     }
-                    
+
                     // Multi-level wildcard: always match the current segment.
                     if (matchSegment.IsMultiLevelWildcard) {
                         return true;
                     }
-                    
+
                     // Not a wildcard; check if the segment values match.
                     return pointer[pointerSegmentIndex].Equals(matchSegment.Segment);
                 });
@@ -271,7 +260,8 @@ namespace Jaahas.Json {
                     if (nonWildcardPointerSet.Contains(pointer)) {
                         return true;
                     }
-                } else if (nonWildcardPointers.Count > 0) {
+                }
+                else if (nonWildcardPointers.Count > 0) {
                     // For partial matches, check each pointer in the list.
                     foreach (var p in nonWildcardPointers) {
                         if (MatchExactOrPartialJsonPointer(context, p, pointer, element)) {
@@ -310,9 +300,9 @@ namespace Jaahas.Json {
         ///   <see langword="false"/>.
         /// </returns>
         /// <remarks>
-        ///   If <paramref name="element"/> is an object or an array and we are running in 
+        ///   If <paramref name="element"/> is an object or an array, and we are running in 
         ///   recursive mode, we will also allow partial matches i.e. if the element pointer has 
-        ///   fewer segments than the match pointer, we will treat it as a match if all of the 
+        ///   fewer segments than the match pointer, we will treat it as a match if all the 
         ///   element pointer segments match their equivalent match pointer segments.
         /// </remarks>
         private static bool MatchExactOrPartialJsonPointer(TimeSeriesExtractorContext context, JsonPointer? matchPointer, JsonPointer elementPointer, JsonElement element) {
@@ -324,9 +314,9 @@ namespace Jaahas.Json {
                 return true;
             }
 
-            if (context.Options.Recursive && (element.ValueKind == JsonValueKind.Object || element.ValueKind == JsonValueKind.Array) && elementPointer.Count < matchPointer.Count) {
-                for (var i = 0; i < elementPointer.Count; i++) {
-                    if (!matchPointer[i].Equals(elementPointer[i])) {
+            if (context.Options.Recursive && element.ValueKind is JsonValueKind.Object or JsonValueKind.Array && elementPointer.SegmentCount < matchPointer.Value.SegmentCount) {
+                for (var i = 0; i < elementPointer.SegmentCount; i++) {
+                    if (!matchPointer.Value.GetSegment(i).Equals(elementPointer[i])) {
                         return false;
                     }
                 }
@@ -457,8 +447,8 @@ namespace Jaahas.Json {
 
             if (!TryGetTimestamp(element, context.Options.TimestampProperty, context.Options, out var sampleTime)) {
                 var ts = options.GetDefaultTimestamp?.Invoke();
-                defaultTimestamp = ts == null 
-                    ? new ParsedTimestamp(DateTimeOffset.UtcNow, TimestampSource.CurrentTime, null) 
+                defaultTimestamp = ts == null
+                    ? new ParsedTimestamp(DateTimeOffset.UtcNow, TimestampSource.CurrentTime, null)
                     : new ParsedTimestamp(ts.Value, TimestampSource.FallbackProvider, null);
             }
             else {
@@ -553,7 +543,7 @@ namespace Jaahas.Json {
             // push the new timestamp onto the stack for use by child elements.
             var popTimestamp = false;
             if (context.Options is { AllowNestedTimestamps: true, TimestampProperty: not null } && TryGetTimestamp(element, context.Options.TimestampProperty, context.Options, out var sampleTime)) {
-                context.TimestampStack.Push(new ParsedTimestamp(sampleTime, TimestampSource.Document, pointer.Combine(context.Options.TimestampProperty!)));
+                context.TimestampStack.Push(new ParsedTimestamp(sampleTime, TimestampSource.Document, pointer.Combine(context.Options.TimestampProperty.Value)));
                 popTimestamp = true;
             }
             // Iterate over each property in the object and process recursively.
@@ -641,7 +631,7 @@ namespace Jaahas.Json {
                 return false;
             }
 
-            var el = pointer.Evaluate(element);
+            var el = pointer.Value.Evaluate(element);
 
             if (el == null) {
                 return false;
@@ -697,7 +687,7 @@ namespace Jaahas.Json {
 
             if (context.IsDefaultSampleKeyTemplate) {
                 // Fast path for default template.
-                return GetFullPropertyName();
+                return GetFullPropertyName().ToString();
             }
 
             if (!context.SampleKeyTemplateContainsPlaceholders) {
@@ -711,7 +701,7 @@ namespace Jaahas.Json {
                     var pName = m.Groups["property"].Value;
 
                     if (string.Equals(pName, "$prop", StringComparison.Ordinal) || string.Equals(pName, "$prop-local", StringComparison.Ordinal)) {
-                        return GetFullPropertyName(string.Equals(pName, "$prop-local", StringComparison.Ordinal));
+                        return GetFullPropertyName(string.Equals(pName, "$prop-local", StringComparison.Ordinal)).ToString();
                     }
 
                     if (string.Equals(pName, "$prop-path", StringComparison.Ordinal)) {
@@ -723,7 +713,7 @@ namespace Jaahas.Json {
                         // stack (starting from the root) and concatenate them using the path separator.
 
                         var hierarchy = context.ElementStack.AsSpan();
-                        var propVals = ArrayPool<string>.Shared.Rent(hierarchy.Length); //new List<string>(hierarchy.Length);
+                        var propVals = ArrayPool<string>.Shared.Rent(hierarchy.Length);
                         var propValsIndex = 0;
 
                         try {
@@ -735,14 +725,12 @@ namespace Jaahas.Json {
                                 if (!stackEntry.Element.TryGetProperty(pName, out var prop)) {
                                     continue;
                                 }
-
-                                //propVals.Add(GetElementDisplayValue(prop));
+                                
                                 propVals[propValsIndex++] = GetElementDisplayValue(prop);
                             }
-
-                            //if (propVals.Count > 0) {
+                            
                             if (propValsIndex > 0) {
-                                return string.Join(options.PathSeparator, new ArraySegment<string?>(propVals, 0, propValsIndex));
+                                return string.Join(options.PathSeparator, (IEnumerable<string?>) new ArraySegment<string?>(propVals, 0, propValsIndex));
                             }
                         }
                         finally {
@@ -775,15 +763,11 @@ namespace Jaahas.Json {
                 : el.GetRawText();
 
             // Gets the name of the current property.
-            string GetFullPropertyName(bool forceLocalName = false) {
+            ReadOnlySpan<char> GetFullPropertyName(bool forceLocalName = false) {
                 if (!options.Recursive || forceLocalName) {
-                    return pointer.Count == 0
+                    return pointer.SegmentCount == 0
                         ? string.Empty
-#if NETCOREAPP
-                        : pointer[^1];
-#else
-                        : pointer[pointer.Count - 1];
-#endif
+                        : pointer[pointer.SegmentCount - 1].AsSpan();
                 }
 
                 var hierarchy = context.ElementStack.AsSpan();
@@ -838,7 +822,7 @@ namespace Jaahas.Json {
 
             // Gets the full path for the current property, not including the actual property name.
             string GetPropertyPath() {
-                if (!options.Recursive || pointer.Count <= 1) {
+                if (!options.Recursive || pointer.SegmentCount <= 1) {
                     return string.Empty;
                 }
 
@@ -860,15 +844,21 @@ namespace Jaahas.Json {
                 }
 
                 if (useDirectPointer) {
-                    var ancestor = pointer.GetAncestor(1);
-                    if (string.Equals(options.PathSeparator, TimeSeriesExtractorConstants.DefaultPathSeparator, StringComparison.Ordinal)) {
-                        var ancestorString = ancestor.ToString();
-                        return ancestorString.Length > 0 && ancestorString[0] == '/'
-                            ? ancestorString.Substring(1)
-                            : ancestorString;
+                    if (sb == null) {
+                        sb = new StringBuilder();
+                    }
+                    else {
+                        sb.Clear();
                     }
 
-                    return string.Join(options.PathSeparator, ancestor);
+                    for (var i = 0; i < pointer.SegmentCount - 1; i++) {
+                        if (i > 0) {
+                            sb.Append(options.PathSeparator);
+                        }
+                        sb.Append(pointer.GetSegment(i).ToString());
+                    }
+
+                    return sb.ToString();
                 }
 
                 if (sb == null) {

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorContext.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorContext.cs
@@ -14,12 +14,12 @@ namespace Jaahas.Json {
         /// Specifies whether the context has been disposed.
         /// </summary>
         private bool _disposed;
-        
+
         /// <summary>
         /// The extractor options.
         /// </summary>
         public TimeSeriesExtractorOptions Options { get; }
-        
+
         /// <summary>
         /// The maximum depth of the JSON document that can be processed.
         /// </summary>
@@ -39,7 +39,7 @@ namespace Jaahas.Json {
         /// Specifies whether the default sample key template is being used.
         /// </summary>
         internal bool IsDefaultSampleKeyTemplate { get; }
-        
+
         /// <summary>
         /// Specifies whether the sample key template contains any placeholders.
         /// </summary>
@@ -60,7 +60,7 @@ namespace Jaahas.Json {
                     ? TimeSeriesExtractorConstants.DefaultMaxDepth
                     : options.MaxDepth
                 : 1;
-            
+
             // We need to add 1 to the maximum depth to allow for the root element.
             ElementStack = new ElementStack(MaxDepth + 1);
             TimestampStack = new TimestampStack(options is { Recursive: true, AllowNestedTimestamps: true } ? MaxDepth : 1);
@@ -73,7 +73,7 @@ namespace Jaahas.Json {
             IsDefaultSampleKeyTemplate = Options.Recursive
                 ? string.Equals(Options.Template, TimeSeriesExtractorConstants.FullPropertyNamePlaceholder, StringComparison.Ordinal)
                 : string.Equals(Options.Template, TimeSeriesExtractorConstants.FullPropertyNamePlaceholder, StringComparison.Ordinal) || string.Equals(Options.Template, TimeSeriesExtractorConstants.LocalPropertyNamePlaceholder, StringComparison.Ordinal);
-            
+
             // We can take a shortcut if the sample key template does not contain any placeholders.
             SampleKeyTemplateContainsPlaceholders = IsDefaultSampleKeyTemplate || Options.Template.Contains("{");
         }
@@ -107,10 +107,10 @@ namespace Jaahas.Json {
             if (_disposed) {
                 return;
             }
-            
+
             ElementStack.Dispose();
             TimestampStack.Dispose();
-            
+
             _disposed = true;
         }
 

--- a/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
+++ b/src/JsonTimeSeriesExtractor/TimeSeriesExtractorOptions.cs
@@ -185,7 +185,7 @@ namespace Jaahas.Json {
         /// A delegate that is used to determine if a JSON element should be processed by the time 
         /// series extractor.
         /// </summary>
-        public JsonPointerMatchDelegate? CanProcessElement { get; set; } 
+        public JsonPointerMatchDelegate? CanProcessElement { get; set; }
 
         /// <summary>
         /// When <see langword="true"/>, JSON properties that contain other objects or arrays will 

--- a/src/JsonTimeSeriesExtractor/TimestampStack.cs
+++ b/src/JsonTimeSeriesExtractor/TimestampStack.cs
@@ -19,7 +19,7 @@ internal sealed class TimestampStack : IDisposable {
     /// Specifies whether the stack has been disposed.
     /// </summary>
     private bool _disposed;
-    
+
     /// <summary>
     /// The backing array.
     /// </summary>
@@ -29,18 +29,18 @@ internal sealed class TimestampStack : IDisposable {
     /// The maximum number of items that can be stored in the stack.
     /// </summary>
     private readonly int _capacity;
-    
+
     /// <summary>
     /// The current number of items in the stack.
     /// </summary>
     private int _count;
-    
+
     /// <summary>
     /// The number of items in the stack.
     /// </summary>
     public int Count => _count;
-    
-    
+
+
     /// <summary>
     /// Creates a new <see cref="TimestampStack"/> instance.
     /// </summary>
@@ -54,12 +54,12 @@ internal sealed class TimestampStack : IDisposable {
         if (capacity <= 0) {
             throw new ArgumentOutOfRangeException(nameof(capacity), Resources.Error_StackCapacityTooSmall);
         }
-        
+
         _capacity = capacity;
         _buffer = ArrayPool<ParsedTimestamp>.Shared.Rent(_capacity);
     }
 
-    
+
     /// <summary>
     /// Pushes an item onto the stack.
     /// </summary>
@@ -79,11 +79,11 @@ internal sealed class TimestampStack : IDisposable {
         if (_count >= _capacity) {
             throw new InvalidOperationException(Resources.Error_StackIsFull);
         }
-        
+
         _buffer[_count++] = entry;
     }
-    
-    
+
+
     /// <summary>
     /// Pops an item from the stack.
     /// </summary>
@@ -103,11 +103,11 @@ internal sealed class TimestampStack : IDisposable {
         if (_count == 0) {
             throw new InvalidOperationException(Resources.Error_StackIsEmpty);
         }
-        
+
         return _buffer[--_count];
     }
-    
-    
+
+
     /// <summary>
     /// Peeks at the item on the top of the stack without removing it.
     /// </summary>
@@ -127,11 +127,11 @@ internal sealed class TimestampStack : IDisposable {
         if (_count == 0) {
             throw new InvalidOperationException(Resources.Error_StackIsEmpty);
         }
-        
+
         return _buffer[_count - 1];
     }
-    
-    
+
+
     /// <summary>
     /// Gets a read-only span of the stack entries.
     /// </summary>
@@ -139,21 +139,21 @@ internal sealed class TimestampStack : IDisposable {
     ///   A read-only span of the stack entries.
     /// </returns>
     public ReadOnlySpan<ParsedTimestamp> AsSpan() => _buffer.AsSpan(0, _count);
-    
-    
+
+
     /// <inheritdoc />
     public void Dispose() {
         if (_disposed) {
             return;
         }
-        
+
         // Manually clear only the used portion to optimize performance while preventing memory leaks
         if (_count > 0) {
             Array.Clear(_buffer, 0, _count);
         }
-        
+
         ArrayPool<ParsedTimestamp>.Shared.Return(_buffer, clearArray: false);
-        
+
         _disposed = true;
     }
 

--- a/test/JsonTimeSeriesExtractor.Benchmarks/JsonTimeSeriesExtractor.Benchmarks.csproj
+++ b/test/JsonTimeSeriesExtractor.Benchmarks/JsonTimeSeriesExtractor.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>net9.0</TargetFramework>
+      <TargetFramework>net10.0</TargetFramework>
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jaahas.Json.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
+++ b/test/JsonTimeSeriesExtractor.Tests/JsonTimeSeriesExtractorTests.cs
@@ -557,7 +557,7 @@ namespace Jaahas.Json.Tests {
                 Template = "{location}/{$prop}",
                 PathSeparator = "/",
                 Recursive = true,
-                CanProcessElement = (_, prop, _) => !prop.Last().Equals("location")
+                CanProcessElement = (_, prop, _) => !prop[prop.SegmentCount - 1].Equals("location")
             }).ToArray();
 
             Assert.Single(samples);
@@ -582,7 +582,7 @@ namespace Jaahas.Json.Tests {
                 Template = "{location}/{$prop-local}",
                 PathSeparator = "/",
                 Recursive = true,
-                CanProcessElement = (_, prop, _) => !prop.Last().Equals("location")
+                CanProcessElement = (_, prop, _) => !prop[prop.SegmentCount - 1].Equals("location")
             }).ToArray();
 
             Assert.Single(samples);


### PR DESCRIPTION
## ⚠️ Breaking Changes

Upgrades JsonPointer.Net to v7.0.0. This version contains several breaking changes compared to the 5.x release used previously, so a major version bump is required here, too.

## Other Changes

Adds `net10.0` targeting and bumps package references.