### PR TITLE
Upgrade NuGet packages to latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,13 +6,13 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
-    <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <GlobalPackageReference Include="PolySharp" Version="1.16.0" />
   </ItemGroup>
   
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="JsonPointer.Net" Version="7.0.0" />
+    <PackageVersion Include="JsonPointer.Net" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
@@ -24,6 +24,6 @@
     </PackageVersion>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 4,
-  "Minor": 0,
+  "Minor": 1,
   "Patch": 0,
   "PreRelease": ""
 }


### PR DESCRIPTION
## Summary
- **JsonPointer.Net**: 7.0.0 → 7.0.1
- **Microsoft.SourceLink.GitHub**: 10.0.102 → 10.0.300
- **PolySharp**: 1.15.0 → 1.16.0
- **System.Text.Json**: 10.0.2 → 10.0.9

Minor version incremented. All 36 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)